### PR TITLE
Add callback for when view attached to window

### DIFF
--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickRecyclerAdapterTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickRecyclerAdapterTest.java
@@ -398,6 +398,15 @@ public class BrickRecyclerAdapterTest {
     }
 
     @Test
+    public void testOnViewAttachedToWindow() {
+        BrickViewHolder brickViewHolder = mock(BrickViewHolder.class);
+
+        adapter.onViewAttachedToWindow(brickViewHolder);
+
+        verify(brickViewHolder).onViewAttachedToWindow();
+    }
+
+    @Test
     public void testOnViewDetachedFromWindow() {
         BrickViewHolder brickViewHolder = mock(BrickViewHolder.class);
 

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -193,6 +193,11 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
     }
 
     @Override
+    public void onViewAttachedToWindow(BrickViewHolder holder) {
+        holder.onViewAttachedToWindow();
+    }
+
+    @Override
     public void onViewDetachedFromWindow(BrickViewHolder holder) {
         holder.releaseViewsOnDetach();
     }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickViewHolder.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickViewHolder.java
@@ -22,6 +22,13 @@ public class BrickViewHolder extends RecyclerView.ViewHolder {
     }
 
     /**
+     * Called when {@link BrickRecyclerAdapter#onViewAttachedToWindow(BrickViewHolder)}
+     * is invoked.
+     */
+    protected void onViewAttachedToWindow() {
+    }
+
+    /**
      * Method called when the view is detached from the {@link RecyclerView}. All views that have resources
      * should release them here (e.g. ImageView).
      */


### PR DESCRIPTION
- Override onViewAttachedToWindow() in BrickRecyclerAdapter and
create a method with the same name in BrickViewHolder that is
called when BrickRecyclerAdapter#onViewAttachedToWindow() is
invoked.

Issue: #32