### PR TITLE
Adding in the ability to specify datamanager layout as either GridLayout or StaggeredGridLayout

### DIFF
--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/MainActivityFragment.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/MainActivityFragment.java
@@ -174,6 +174,28 @@ public class MainActivityFragment extends BrickFragment {
                             }
                         },
                         padding,
+                        "Staggered Infinite Scroll Brick View",
+                        new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                getFragmentManager().beginTransaction()
+                                        .replace(R.id.content, new StaggeredInfiniteScrollBrickFragment())
+                                        .addToBackStack(null)
+                                        .commit();
+                            }
+                        }
+                )
+        );
+        usedBricks.add(
+                new UsedBrick(
+                        getContext(),
+                        new SimpleBrickSize(maxSpans()) {
+                            @Override
+                            protected int size() {
+                                return TWO_FIFTH;
+                            }
+                        },
+                        padding,
                         "Fragment Brick View",
                         new View.OnClickListener() {
                             @Override

--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/StaggeredInfiniteScrollBrickFragment.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/StaggeredInfiniteScrollBrickFragment.java
@@ -1,0 +1,96 @@
+package com.wayfair.brickkitdemo;
+
+/**
+ * Copyright © 2017 Wayfair. All rights reserved.
+ */
+
+import android.os.Bundle;
+import android.support.v7.widget.StaggeredGridLayoutManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.wayfair.brickkit.BrickFragment;
+import com.wayfair.brickkit.OnReachedItemAtPosition;
+import com.wayfair.brickkit.brick.BaseBrick;
+import com.wayfair.brickkit.brick.TextBrick;
+import com.wayfair.brickkit.padding.InnerOuterBrickPadding;
+import com.wayfair.brickkit.size.OrientationBrickSize;
+
+/**
+ * Example fragment which loads more bricks when scrolling to the bottom.
+ * <p>
+ * This fragment takes advantage of the {@link OnReachedItemAtPosition} which calls back when
+ * items are bound in the adapter.
+ */
+public class StaggeredInfiniteScrollBrickFragment extends BrickFragment {
+    private static final int HALF = 120;
+
+    private int page = 0;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        addNewBricks();
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
+        dataManager.applyStaggeredGridLayout(2, StaggeredGridLayoutManager.VERTICAL);
+        dataManager.getBrickRecyclerAdapter().setOnReachedItemAtPosition(
+                new OnReachedItemAtPosition() {
+                    @Override
+                    public void bindingItemAtPosition(int position) {
+                        if (position == dataManager.getRecyclerViewItems().size() - 1) {
+                            page++;
+                            addNewBricks();
+                        }
+                    }
+                }
+        );
+
+        return view;
+    }
+
+    /**
+     * Method to add 100 new text bricks to the data manager.
+     */
+    private void addNewBricks() {
+        String text = "Brick: " + page + " ";
+        String textToAppend;
+        for (int i = 0; i < 100; i++) {
+
+            if (i % 19 == 0) {
+                textToAppend = "fullsize ";
+            } else if (i % 4 == 0) {
+                textToAppend = "multi\nline ";
+            } else {
+                textToAppend = "";
+            }
+            textToAppend += String.valueOf(i);
+
+            BaseBrick unusedBrick2 = new TextBrick(
+                    getContext(),
+                    new OrientationBrickSize(maxSpans()) {
+                        @Override
+                        protected int portrait() {
+                            return dataManager.getMaxSpanCount();
+                        }
+
+                        @Override
+                        protected int landscape() {
+                            return HALF;
+                        }
+                    },
+                    new InnerOuterBrickPadding(5, 10),
+                    text + textToAppend
+            );
+            if (i % 19 == 0) {
+                unusedBrick2.setFullSize(true);
+            }
+            dataManager.addLast(unusedBrick2);
+        }
+    }
+}

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
@@ -10,6 +10,7 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.view.View;
 
 import com.wayfair.brickkit.behavior.BrickBehavior;
@@ -1215,5 +1216,18 @@ public class BrickDataManagerTest {
     public void testSmoothScrollToBrick() {
         manager.smoothScrollToBrick(manager.brickAtPosition(manager.getRecyclerViewItems().size() - 1));
         manager.smoothScrollToBrick(brickTestHelper.generateBrick());
+    }
+
+    @Test
+    public void testApplyGridLayout() {
+        manager.applyGridLayout(GridLayoutManager.VERTICAL, true);
+        assertTrue(manager.getRecyclerView().getLayoutManager() instanceof GridLayoutManager);
+    }
+
+    @Test
+    public void testApplyStaggeredGridLayout() {
+        manager.applyStaggeredGridLayout(2, StaggeredGridLayoutManager.VERTICAL);
+        assertTrue(manager.getRecyclerView().getLayoutManager() instanceof StaggeredGridLayoutManager);
+        assertFalse(manager.getRecyclerView().getLayoutManager().isItemPrefetchEnabled());
     }
 }

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickRecyclerAdapterTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickRecyclerAdapterTest.java
@@ -558,4 +558,5 @@ public class BrickRecyclerAdapterTest {
     public void testGetSectionFooterBadPosition() {
         assertNull(adapter.getSectionFooter(-1));
     }
+
 }

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/BaseBrickTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/BaseBrickTest.java
@@ -71,6 +71,16 @@ public class BaseBrickTest {
     }
 
     @Test
+    public void testFullSize() {
+        TestBaseBrick brick = new TestBaseBrick(context, brickSize);
+
+        assertFalse(brick.isFullSize());
+
+        brick.setFullSize(true);
+        assertTrue(brick.isFullSize());
+    }
+
+    @Test
     public void testHeader() {
         TestBaseBrick brick = new TestBaseBrick(context, brickSize);
 

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -5,6 +5,7 @@ package com.wayfair.brickkit;
 
 import android.os.Handler;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -194,9 +195,22 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         BaseBrick baseBrick = dataManager.brickAtPosition(position);
 
         if (baseBrick != null) {
+            applyFullSpan(holder, baseBrick);
+
             baseBrick.onBindData(holder);
             if (onReachedItemAtPosition != null) {
                 onReachedItemAtPosition.bindingItemAtPosition(position);
+            }
+        }
+    }
+
+    public void applyFullSpan(BrickViewHolder holder, BaseBrick baseBrick) {
+        if (recyclerView.getLayoutManager() instanceof StaggeredGridLayoutManager) {
+            StaggeredGridLayoutManager.LayoutParams layoutParams = (StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams();
+            if (baseBrick.isFullSize()) {
+                layoutParams.setFullSpan(true);
+            } else {
+                layoutParams.setFullSpan(false);
             }
         }
     }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
@@ -31,6 +31,7 @@ public abstract class BaseBrick {
     private boolean isOnRightWall;
     @StickyScrollMode
     private int stickyScrollMode = StickyScrollMode.SHOW_ON_SCROLL;
+    private boolean fullSize;
 
     /**
      * Constructor.
@@ -161,6 +162,26 @@ public abstract class BaseBrick {
      */
     public void setStickyScrollMode(@StickyScrollMode int stickyScrollMode) {
         this.stickyScrollMode = stickyScrollMode;
+    }
+
+    /**
+     * Whether the brick should take up the width or height of the fragment
+     * This is important for the StaggeredGridLayout, because it allows for different column sizes.
+     *
+     * @return true if the brick takes up the whole row, false otherwise
+     */
+    public boolean isFullSize() {
+        return fullSize;
+    }
+    
+    /**
+     * Set whether the brick should take up the whole row.
+     * This is only important for the StaggeredGridLayout.
+     *
+     * @param fullSize whether the brick should take up the whole row
+     */
+    public void setFullSize(boolean fullSize) {
+        this.fullSize = fullSize;
     }
 
     /**


### PR DESCRIPTION
Allows for the datamanager to switch layouts by having applyGridLayout() and applyStaggeredGridLayout() methods. The staggered grid layout is able to show fullsize bricks, which take up the width (or height if horizontal) of the screen. Also adds in a new demo showcasing this ability.