### PR TITLE
Fix for getSpanSize() support lib bug

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickSpanSizeLookup.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickSpanSizeLookup.java
@@ -29,8 +29,13 @@ class BrickSpanSizeLookup extends GridLayoutManager.SpanSizeLookup {
 
     @Override
     public int getSpanSize(int position) {
-        BaseBrick brick = brickDataManager.getRecyclerViewItems().get(position);
+        try {
+            BaseBrick brick = brickDataManager.getRecyclerViewItems().get(position);
 
-        return brick != null ? brick.getSpanSize().getSpans(context) : 1;
+            return brick != null ? brick.getSpanSize().getSpans(context) : 1;
+        } catch (IndexOutOfBoundsException e) {
+            // Appears to be a bug in the support lib.
+            return 1;
+        }
     }
 }


### PR DESCRIPTION
- Catch IndexOutOfBoundsException in getSpanSize() to circumvent
support lib bug.

Fixes #45