### PR TITLE
Fixing crash when staggeredgrid used with header

### DIFF
--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
@@ -1229,5 +1229,6 @@ public class BrickDataManagerTest {
         manager.applyStaggeredGridLayout(2, StaggeredGridLayoutManager.VERTICAL);
         assertTrue(manager.getRecyclerView().getLayoutManager() instanceof StaggeredGridLayoutManager);
         assertFalse(manager.getRecyclerView().getLayoutManager().isItemPrefetchEnabled());
+        assertFalse(manager.getRecyclerView().getLayoutManager().supportsPredictiveItemAnimations());
     }
 }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -78,9 +78,29 @@ public class BrickDataManager implements Serializable {
      */
     public void applyStaggeredGridLayout(int spanCount, int orientation) {
         if (recyclerView != null) {
-            StaggeredGridLayoutManager staggeredGridLayoutManager = new StaggeredGridLayoutManager(spanCount, orientation);
+            StaggeredGridLayoutManager staggeredGridLayoutManager = new NpaStaggeredGridLayoutManager(spanCount, orientation);
             staggeredGridLayoutManager.setItemPrefetchEnabled(false);
             recyclerView.setLayoutManager(staggeredGridLayoutManager);
+        }
+    }
+
+    /**
+     * Non-Predictive Animations {@link StaggeredGridLayoutManager}
+     */
+    private static class NpaStaggeredGridLayoutManager extends StaggeredGridLayoutManager {
+        NpaStaggeredGridLayoutManager(int spanCount, int orientation) {
+            super(spanCount, orientation);
+        }
+
+        /**
+         * There is a bug in recyclerviews (March 2017) which causes them to load animations for views which don't yet exist.
+         * For us this is a race condition, it currently only occurs on the infinite brick pages.
+         *
+         * @return false
+         */
+        @Override
+        public boolean supportsPredictiveItemAnimations() {
+            return false;
         }
     }
 

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -912,15 +912,15 @@ public class BrickDataManager implements Serializable {
     }
 
     /**
-     * Non-Predictive Animations {@link StaggeredGridLayoutManager}
+     * Non-Predictive Animations {@link StaggeredGridLayoutManager}.
      */
     private static class NpaStaggeredGridLayoutManager extends StaggeredGridLayoutManager {
-        
+
         /**
          * Constructor for the NpaStaggeredGridLayoutManager.
          *
-         * @param spanCount
-         * @param orientation
+         * @param spanCount the number of columns to use in the StaggeredGridLayoutManager.
+         * @param orientation the orientation of the StaggeredGridLayoutManager.
          */
         NpaStaggeredGridLayoutManager(int spanCount, int orientation) {
             super(spanCount, orientation);

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -70,8 +70,8 @@ public class BrickDataManager implements Serializable {
 
     /**
      * Sets the layout for the recyclerview to be a StaggeredGridLayout.
-     * setItemPrefetch is disabled because of a known android bug (March 2016)
-     * which creates a fatal on staggeredGrid when scrolling quickly while paging.
+     * SetItemPrefetch is disabled because of a known android bug (March 2016).
+     * It creates a fatal on staggeredGrid when scrolling quickly while paging.
      *
      * @param spanCount   the number of columns to which the bricks will conform
      * @param orientation the orientation of the layout
@@ -81,26 +81,6 @@ public class BrickDataManager implements Serializable {
             StaggeredGridLayoutManager staggeredGridLayoutManager = new NpaStaggeredGridLayoutManager(spanCount, orientation);
             staggeredGridLayoutManager.setItemPrefetchEnabled(false);
             recyclerView.setLayoutManager(staggeredGridLayoutManager);
-        }
-    }
-
-    /**
-     * Non-Predictive Animations {@link StaggeredGridLayoutManager}
-     */
-    private static class NpaStaggeredGridLayoutManager extends StaggeredGridLayoutManager {
-        NpaStaggeredGridLayoutManager(int spanCount, int orientation) {
-            super(spanCount, orientation);
-        }
-
-        /**
-         * There is a bug in recyclerviews (March 2017) which causes them to load animations for views which don't yet exist.
-         * For us this is a race condition, it currently only occurs on the infinite brick pages.
-         *
-         * @return false
-         */
-        @Override
-        public boolean supportsPredictiveItemAnimations() {
-            return false;
         }
     }
 
@@ -929,5 +909,32 @@ public class BrickDataManager implements Serializable {
             return getRecyclerViewItems().get(position);
         }
         return null;
+    }
+
+    /**
+     * Non-Predictive Animations {@link StaggeredGridLayoutManager}
+     */
+    private static class NpaStaggeredGridLayoutManager extends StaggeredGridLayoutManager {
+        
+        /**
+         * Constructor for the NpaStaggeredGridLayoutManager.
+         *
+         * @param spanCount
+         * @param orientation
+         */
+        NpaStaggeredGridLayoutManager(int spanCount, int orientation) {
+            super(spanCount, orientation);
+        }
+
+        /**
+         * There is a bug in recyclerviews (March 2017) which causes them to load animations for views which don't yet exist.
+         * For us this is a race condition, it currently only occurs on the infinite brick pages.
+         *
+         * @return false
+         */
+        @Override
+        public boolean supportsPredictiveItemAnimations() {
+            return false;
+        }
     }
 }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -193,17 +193,12 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
     @Override
     public void onBindViewHolder(BrickViewHolder holder, int position) {
         BaseBrick baseBrick = dataManager.brickAtPosition(position);
-
+        boolean isFullSpan;
         if (baseBrick != null) {
+            isFullSpan = baseBrick.getSpanSize().getSpans(recyclerView.getContext()) == dataManager.getMaxSpanCount();
             if (recyclerView.getLayoutManager() instanceof StaggeredGridLayoutManager) {
                 if (holder.itemView.getLayoutParams() instanceof StaggeredGridLayoutManager.LayoutParams) {
-                    StaggeredGridLayoutManager.LayoutParams layoutParams =
-                            (StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams();
-                    if (baseBrick.getSpanSize().getSpans(recyclerView.getContext()) == dataManager.getMaxSpanCount()) {
-                        layoutParams.setFullSpan(true);
-                    } else {
-                        layoutParams.setFullSpan(false);
-                    }
+                    ((StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams()).setFullSpan(isFullSpan);
                 }
             }
             baseBrick.onBindData(holder);

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -193,12 +193,11 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
     @Override
     public void onBindViewHolder(BrickViewHolder holder, int position) {
         BaseBrick baseBrick = dataManager.brickAtPosition(position);
-        boolean isFullSpan;
         if (baseBrick != null) {
-            isFullSpan = baseBrick.getSpanSize().getSpans(recyclerView.getContext()) == dataManager.getMaxSpanCount();
             if (recyclerView.getLayoutManager() instanceof StaggeredGridLayoutManager) {
                 if (holder.itemView.getLayoutParams() instanceof StaggeredGridLayoutManager.LayoutParams) {
-                    ((StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams()).setFullSpan(isFullSpan);
+                    ((StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams()).setFullSpan(
+                            baseBrick.getSpanSize().getSpans(recyclerView.getContext()) == dataManager.getMaxSpanCount());
                 }
             }
             baseBrick.onBindData(holder);

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -196,11 +196,13 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
 
         if (baseBrick != null) {
             if (recyclerView.getLayoutManager() instanceof StaggeredGridLayoutManager) {
-                StaggeredGridLayoutManager.LayoutParams layoutParams = (StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams();
-                if (baseBrick.getSpanSize().getSpans(recyclerView.getContext()) == dataManager.getMaxSpanCount()) {
-                    layoutParams.setFullSpan(true);
-                } else {
-                    layoutParams.setFullSpan(false);
+                if(holder.itemView.getLayoutParams() instanceof StaggeredGridLayoutManager.LayoutParams){
+                    StaggeredGridLayoutManager.LayoutParams layoutParams = (StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams();
+                    if (baseBrick.getSpanSize().getSpans(recyclerView.getContext()) == dataManager.getMaxSpanCount()) {
+                        layoutParams.setFullSpan(true);
+                    } else {
+                        layoutParams.setFullSpan(false);
+                    }
                 }
             }
             baseBrick.onBindData(holder);

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -196,8 +196,9 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
 
         if (baseBrick != null) {
             if (recyclerView.getLayoutManager() instanceof StaggeredGridLayoutManager) {
-                if(holder.itemView.getLayoutParams() instanceof StaggeredGridLayoutManager.LayoutParams){
-                    StaggeredGridLayoutManager.LayoutParams layoutParams = (StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams();
+                if (holder.itemView.getLayoutParams() instanceof StaggeredGridLayoutManager.LayoutParams) {
+                    StaggeredGridLayoutManager.LayoutParams layoutParams =
+                            (StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams();
                     if (baseBrick.getSpanSize().getSpans(recyclerView.getContext()) == dataManager.getMaxSpanCount()) {
                         layoutParams.setFullSpan(true);
                     } else {

--- a/BrickKit/bricks/src/main/res/layout/vertical_header.xml
+++ b/BrickKit/bricks/src/main/res/layout/vertical_header.xml
@@ -14,6 +14,7 @@
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:gravity="center"
+        tools:background="@android:color/white"
         tools:layout_height="40dp"/>
 
     <ImageView

--- a/BrickKit/bricks/src/main/res/layout/vertical_header.xml
+++ b/BrickKit/bricks/src/main/res/layout/vertical_header.xml
@@ -7,6 +7,7 @@
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
     android:orientation="vertical"
+    android:background="@android:color/white"
     android:layout_gravity="center_horizontal|top">
 
     <RelativeLayout
@@ -14,7 +15,6 @@
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:gravity="center"
-        tools:background="@android:color/white"
         tools:layout_height="40dp"/>
 
     <ImageView

--- a/BrickKit/bricks/src/main/res/layout/vertical_header.xml
+++ b/BrickKit/bricks/src/main/res/layout/vertical_header.xml
@@ -7,7 +7,6 @@
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
     android:orientation="vertical"
-    android:background="@android:color/white"
     android:layout_gravity="center_horizontal|top">
 
     <RelativeLayout


### PR DESCRIPTION
When headers were used with the StaggeredGridLayout, the app would crash if predictive animations are enabled and the user scrolled quickly. They would also only show a background on the text layout, not on the brick that contained the layout.