### PR TITLE
Allow view modifications in placeholders

### DIFF
--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/bricks/UsedBrick.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/bricks/UsedBrick.java
@@ -67,6 +67,11 @@ public class UsedBrick extends BaseBrick implements TouchableBrick {
     }
 
     @Override
+    public void onBindPlaceholder(BrickViewHolder holder) {
+        // Here we would modify placeholder views dimensions if necessary
+    }
+
+    @Override
     public int getLayout() {
         return R.layout.used_brick;
     }

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickRecyclerAdapterTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickRecyclerAdapterTest.java
@@ -399,7 +399,7 @@ public class BrickRecyclerAdapterTest {
 
         adapter.onBindViewHolder(holder, 0);
 
-        verify(brick, times(0)).onBindData(holder);
+        verify(brick).onBindPlaceholder(holder);
     }
 
     @Test
@@ -416,7 +416,7 @@ public class BrickRecyclerAdapterTest {
 
         adapter.onBindViewHolder(holder, 0);
 
-        verify(brick, times(0)).onBindData(holder);
+        verify(brick).onBindPlaceholder(holder);
         verify(listener).bindingItemAtPosition(0);
     }
 

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -208,6 +208,8 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
 
             if (baseBrick.isDataReady()) {
                 baseBrick.onBindData(holder);
+            } else {
+                baseBrick.onBindPlaceholder(holder);
             }
             if (onReachedItemAtPosition != null) {
                 onReachedItemAtPosition.bindingItemAtPosition(position);

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
@@ -68,8 +68,8 @@ public abstract class BaseBrick {
      * @param holder BrickViewHolder which should be updated.
      */
     public void onBindPlaceholder(BrickViewHolder holder) {
-        throw new UnsupportedOperationException(getClass().getSimpleName() +
-                " onBindPlaceholder(BrickViewHolder holder) method must be overridden within brick extending BaseBrick");
+        throw new UnsupportedOperationException(getClass().getSimpleName()
+                + " onBindPlaceholder(BrickViewHolder holder) method must be overridden within brick extending BaseBrick");
     }
 
     /**

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
@@ -62,6 +62,17 @@ public abstract class BaseBrick {
     public abstract void onBindData(BrickViewHolder holder);
 
     /**
+     * Called by the BrickRecyclerAdapter to display the information in this brick placeholder to the specified
+     * ViewHolder.
+     *
+     * @param holder BrickViewHolder which should be updated.
+     */
+    public void onBindPlaceholder(BrickViewHolder holder) {
+        throw new UnsupportedOperationException(getClass().getSimpleName() +
+                " onBindPlaceholder(BrickViewHolder holder) method must be overridden within brick extending BaseBrick");
+    }
+
+    /**
      * Get layout resource id for this brick.
      *
      * @return the layout resource id for this brick


### PR DESCRIPTION
Add onBindPlaceholder method within BaseBrick in order to have full control over placeholder views.
This method will be called instead of the onBindData method by the BrickRecyclerAdapter when data is still not ready.