### PR TITLE
StickyHeaderBehavior causes crash when removing items

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/behavior/StickyHeaderBehavior.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/behavior/StickyHeaderBehavior.java
@@ -45,6 +45,16 @@ public class StickyHeaderBehavior extends StickyViewBehavior {
         if (adapterPosHere == RecyclerView.NO_POSITION) {
             View firstChild = adapter.getRecyclerView().getChildAt(0);
             adapterPosHere = adapter.getRecyclerView().getChildAdapterPosition(firstChild);
+
+            // Following condition happens only when removing items and having sticky header behavior.
+            // The child at position 0, which is the first VISIBLE view is one of the views that just got removed.
+            // For some reason that view is still alive within the recyclerView(probably computing layout).
+            // When getSectionHeader is trying to access that position within the recyclerViewItems, that position
+            // won't exist since data manager recyclerViewItems linked list just removed it. That will follow up
+            // with an indexOfBoundsException and crash the app.
+            if (adapterPosHere == adapter.getItemCount()) {
+                return RecyclerView.NO_POSITION;
+            }
         }
         BaseBrick header = adapter.getSectionHeader(adapterPosHere);
         //Header cannot be sticky if it's also an Expandable in collapsed status, RV will raise an exception


### PR DESCRIPTION
Check if adapter position is valid when getting it from a view within the recyclerview and avoid triggering getSectionHeader with an invalid position.

User case (This is also explained within the StickyHeaderBehavior.java file):
When removing items and having sticky header behavior the following happens:
The child at position 0, which is the first VISIBLE view is one of the views that just got removed.
For some reason that view is still alive within the recyclerView(probably computing layout).
When getSectionHeader is trying to access that position within the recyclerViewItems, that position
won't exist since data manager recyclerViewItems linked list just removed the items. That will follow up with an indexOfBoundsException and crash the app.