### PR TITLE
Introduce the ViewModelBrick into BrickKit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,11 @@ android:
     - android-24
     - android-25
     - android-26
+    - android-27
     - extra-android-support
     - extra-google-m2repository
     - extra-android-m2repository
     - sys-img-armeabi-v7a-android-24
-
-before_install:
-  - yes | sdkmanager "platforms;android-24;android-25;android-26;android-27"
 before_script:
   - echo no | android create avd --force -n test -t android-24 --abi armeabi-v7a
   - emulator -avd test -no-window &

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,22 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-25.0.2
+    - build-tools-26.0.3
     - android-24
     - android-25
+    - android-26
     - extra-android-support
     - extra-google-m2repository
     - extra-android-m2repository
     - sys-img-armeabi-v7a-android-24
 
+before_install:
+  - yes | sdkmanager "platforms;android-24;android-25;android-26;android-27"
 before_script:
   - echo no | android create avd --force -n test -t android-24 --abi armeabi-v7a
   - emulator -avd test -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-
 script:
   - cd BrickKit
   - ./gradlew build connectedCheck createPom createBintrayDescriptor

--- a/BrickKit/app/build.gradle
+++ b/BrickKit/app/build.gradle
@@ -1,13 +1,15 @@
 apply plugin: 'com.android.application'
 apply plugin: 'checkstyle'
 
+ext.androidSupportVersion = '26.1.0'
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion '26.0.3'
     defaultConfig {
         applicationId 'com.wayfair.brickkitdemo'
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -18,8 +20,14 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            testCoverageEnabled true
+        }
     }
     productFlavors {
+    }
+    dataBinding {
+        enabled = true
     }
 }
 
@@ -30,15 +38,15 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile 'com.android.support:support-v4:25.1.0'
-    compile 'com.android.support:support-v13:25.1.0'
-    compile 'com.android.support:support-compat:25.1.0'
-    compile 'com.android.support:support-core-utils:25.1.0'
-    compile 'com.android.support:support-core-ui:25.1.0'
-    compile 'com.android.support:support-fragment:25.1.0'
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
-    compile 'com.android.support:design:25.1.0'
+    compile "com.android.support:support-v4:${androidSupportVersion}"
+    compile "com.android.support:support-v13:${androidSupportVersion}"
+    compile "com.android.support:support-compat:${androidSupportVersion}"
+    compile "com.android.support:support-core-utils:${androidSupportVersion}"
+    compile "com.android.support:support-core-ui:${androidSupportVersion}"
+    compile "com.android.support:support-fragment:${androidSupportVersion}"
+    compile "com.android.support:appcompat-v7:${androidSupportVersion}"
+    compile "com.android.support:recyclerview-v7:${androidSupportVersion}"
+    compile "com.android.support:design:${androidSupportVersion}"
     compile 'com.facebook.shimmer:shimmer:0.1.0@aar'
 
     testCompile 'junit:junit:4.12'

--- a/BrickKit/app/build.gradle
+++ b/BrickKit/app/build.gradle
@@ -20,9 +20,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-        debug {
-            testCoverageEnabled true
-        }
     }
     productFlavors {
     }

--- a/BrickKit/app/src/main/AndroidManifest.xml
+++ b/BrickKit/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
 
     <application
         android:allowBackup="true"
+        android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/ControllerDataModel.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/ControllerDataModel.java
@@ -1,0 +1,38 @@
+package com.wayfair.brickkitdemo;
+
+import com.wayfair.brickkit.brick.DataModel;
+
+/**
+ * Data model for a controller brick.
+ */
+public class ControllerDataModel extends DataModel {
+    private int value;
+
+    /**
+     * Constructor with a starting value.
+     *
+     * @param value the starting value
+     */
+    public ControllerDataModel(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Change the value.
+     *
+     * @param value the new value
+     */
+    public void setValue(int value) {
+        this.value = value;
+        notifyChange();
+    }
+
+    /**
+     * Get the current value.
+     *
+     * @return the value
+     */
+    public int getValue() {
+        return this.value;
+    }
+}

--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/ControllerViewModel.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/ControllerViewModel.java
@@ -1,0 +1,83 @@
+package com.wayfair.brickkitdemo;
+
+import android.databinding.Bindable;
+import android.text.Editable;
+import android.text.TextWatcher;
+
+import com.wayfair.brickkit.brick.ViewModel;
+
+/**
+ * A sample brick.
+ *
+ * Copyright © 2017 Wayfair. All rights reserved.
+ */
+public class ControllerViewModel extends ViewModel<ControllerDataModel> {
+    private final Runnable removeAction;
+    private final Runnable addAction;
+
+    /**
+     * Constructor.
+     *
+     * @param dataModel the data model to drive the view model
+     * @param removeAction the runnable for removing an item
+     * @param addAction the runnable for adding an item
+     */
+    public ControllerViewModel(ControllerDataModel dataModel, Runnable removeAction, Runnable addAction) {
+        super(dataModel);
+
+        this.removeAction = removeAction;
+        this.addAction = addAction;
+    }
+
+    /**
+     * Get the value of the {@link ControllerDataModel#getValue()}.
+     *
+     * @return the {@link ControllerDataModel#getValue()}
+     */
+    @Bindable
+    public String getValue() {
+        return String.valueOf(getDataModel().getValue());
+    }
+
+    /**
+     * Run the remove runnable.
+     */
+    public void remove() {
+        removeAction.run();
+    }
+
+    /**
+     * Run the add runnable.
+     */
+    public void add() {
+        addAction.run();
+    }
+
+    /**
+     * Create a new {@link TextWatcher}.
+     *
+     * @return the new {@link TextWatcher}
+     */
+    public TextWatcher getTextWatcher() {
+        return new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                try {
+                    getDataModel().setValue(Integer.valueOf(charSequence.toString()));
+                } catch (NumberFormatException e) {
+                    getDataModel().setValue(0);
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+
+            }
+        };
+    }
+}

--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/EditTextBindingAdapters.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/EditTextBindingAdapters.java
@@ -1,0 +1,30 @@
+package com.wayfair.brickkitdemo;
+
+import android.databinding.BindingAdapter;
+import android.support.design.widget.TextInputEditText;
+
+/**
+ * Binding adapters for {@link TextInputEditText}.
+ */
+public final class EditTextBindingAdapters {
+
+    /**
+     * Private Constructor.
+     */
+    private EditTextBindingAdapters() {
+
+    }
+
+    /**
+     * Bind the {@link android.text.TextWatcher} to the {@link TextInputEditText}.
+     *
+     * @param editText the {@link TextInputEditText}
+     * @param controllerViewModel the {@link ControllerViewModel} that provides
+     *                            a {@link android.text.TextWatcher}
+     */
+    @BindingAdapter("textChangedListener")
+    public static void bindTextWatcher(TextInputEditText editText, ControllerViewModel controllerViewModel) {
+        editText.addTextChangedListener(controllerViewModel.getTextWatcher());
+        editText.setSelection(controllerViewModel.getValue().length());
+    }
+}

--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/SimpleBrickFragment.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/SimpleBrickFragment.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.wayfair.brickkit.BrickFragment;
+import com.wayfair.brickkit.brick.BaseBrick;
 import com.wayfair.brickkit.brick.SwipeListener;
 import com.wayfair.brickkit.brick.ViewModelBrick;
 import com.wayfair.brickkit.models.TextDataModel;
@@ -15,21 +16,24 @@ import com.wayfair.brickkit.models.TextViewModel;
 import com.wayfair.brickkit.padding.InnerOuterBrickPadding;
 import com.wayfair.brickkit.size.OrientationBrickSize;
 
+import java.util.LinkedList;
 import java.util.Timer;
 import java.util.TimerTask;
 
 /**
  * Example fragment which shows text bricks.
- *
+ * <p>
  * In portrait, the bricks are full width.
  * In landscape the bricks are half width.
- *
+ * <p>
  * Copyright © 2017 Wayfair. All rights reserved.
  */
 public class SimpleBrickFragment extends BrickFragment {
     private static final int HALF = 120;
 
     private int numberOfBricks = 100;
+
+    LinkedList<BaseBrick> bricks;
 
     /**
      * Create a new instance of a SimpleBrickFragment.
@@ -43,67 +47,17 @@ public class SimpleBrickFragment extends BrickFragment {
         return fragment;
     }
 
-        @Override
-        public void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
-            ViewModelBrick[] bricks = new ViewModelBrick[numberOfBricks];
+        bricks = new LinkedList<>();
 
         for (int i = 0; i < numberOfBricks; i++) {
-            final TextDataModel dataModel = new TextDataModel("Brick: " + i);
+            ViewModelBrick brick = genBrick(i);
 
-            new Timer().schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    dataModel.appendText(" Hello");
-                }
-
-            }, 0, 1000);
-
-            bricks[i] = new ViewModelBrick.Builder(R.layout.text_brick_vm)
-                    .setPadding(new InnerOuterBrickPadding(5, 10))
-                    .setSpanSize(
-                            new OrientationBrickSize(maxSpans()) {
-                                @Override
-                                protected int portrait() {
-                                    return dataManager.getMaxSpanCount();
-                                }
-
-                                @Override
-                                protected int landscape() {
-                                    return HALF;
-                                }
-                            }
-                    )
-                    .addViewModel(
-                            BR.textViewModel,
-                            new TextViewModel(dataModel)
-                    )
-                    .build();
-
-            bricks[i].setOnDismiss(
-                    new SwipeListener() {
-                        @Override
-                        public void swiped(int direction) {
-                            if (direction == ItemTouchHelper.RIGHT
-                                    || direction == ItemTouchHelper.END) {
-                                Snackbar.make(
-                                        dataManager.getBrickRecyclerAdapter().getRecyclerView(),
-                                        "Moved " + dataModel.getText(),
-                                        Snackbar.LENGTH_SHORT
-                                ).show();
-                            } else if (direction == ItemTouchHelper.LEFT
-                                    || direction == ItemTouchHelper.START) {
-                                Snackbar.make(
-                                        dataManager.getBrickRecyclerAdapter().getRecyclerView(),
-                                        "Deleted " + dataModel.getText(),
-                                        Snackbar.LENGTH_SHORT
-                                ).show();
-                            }
-                        }
-                    }
-            );
-            dataManager.addLast(bricks[i]);
+            bricks.add(brick);
+            dataManager.addLast(brick);
         }
     }
 
@@ -114,5 +68,69 @@ public class SimpleBrickFragment extends BrickFragment {
         dataManager.setSwipeToDismiss(true);
 
         return view;
+    }
+
+    /**
+     * Generate a brick.
+     *
+     * @param i the index of that brick, also uses in the text of the brick
+     * @return the brick
+     */
+    public ViewModelBrick genBrick(int i) {
+        final TextDataModel dataModel = new TextDataModel("Brick: " + i);
+
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                dataModel.appendText(" Hello");
+            }
+
+        }, 0, 1000);
+
+        ViewModelBrick brick = new ViewModelBrick.Builder(R.layout.text_brick_vm)
+                .setPadding(new InnerOuterBrickPadding(5, 10))
+                .setSpanSize(
+                        new OrientationBrickSize(maxSpans()) {
+                            @Override
+                            protected int portrait() {
+                                return dataManager.getMaxSpanCount();
+                            }
+
+                            @Override
+                            protected int landscape() {
+                                return HALF;
+                            }
+                        }
+                )
+                .addViewModel(
+                        BR.textViewModel,
+                        new TextViewModel(dataModel)
+                )
+                .build();
+
+        brick.setOnDismiss(
+                new SwipeListener() {
+                    @Override
+                    public void swiped(int direction) {
+                        if (direction == ItemTouchHelper.RIGHT
+                                || direction == ItemTouchHelper.END) {
+                            Snackbar.make(
+                                    dataManager.getBrickRecyclerAdapter().getRecyclerView(),
+                                    "Moved " + dataModel.getText(),
+                                    Snackbar.LENGTH_SHORT
+                            ).show();
+                        } else if (direction == ItemTouchHelper.LEFT
+                                || direction == ItemTouchHelper.START) {
+                            Snackbar.make(
+                                    dataManager.getBrickRecyclerAdapter().getRecyclerView(),
+                                    "Deleted " + dataModel.getText(),
+                                    Snackbar.LENGTH_SHORT
+                            ).show();
+                        }
+                    }
+                }
+        );
+
+        return brick;
     }
 }

--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/SimpleBrickFragment.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/SimpleBrickFragment.java
@@ -1,31 +1,35 @@
-/**
- * Copyright © 2017 Wayfair. All rights reserved.
- */
 package com.wayfair.brickkitdemo;
 
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.wayfair.brickkit.BrickFragment;
+import com.wayfair.brickkit.brick.SwipeListener;
+import com.wayfair.brickkit.brick.ViewModelBrick;
+import com.wayfair.brickkit.models.TextDataModel;
+import com.wayfair.brickkit.models.TextViewModel;
 import com.wayfair.brickkit.padding.InnerOuterBrickPadding;
 import com.wayfair.brickkit.size.OrientationBrickSize;
-import com.wayfair.brickkit.brick.TextBrick;
+
+import java.util.Timer;
+import java.util.TimerTask;
 
 /**
  * Example fragment which shows text bricks.
  *
  * In portrait, the bricks are full width.
  * In landscape the bricks are half width.
+ *
+ * Copyright © 2017 Wayfair. All rights reserved.
  */
 public class SimpleBrickFragment extends BrickFragment {
     private static final int HALF = 120;
 
     private int numberOfBricks = 100;
-
-    private TextBrick[] bricks;
 
     /**
      * Create a new instance of a SimpleBrickFragment.
@@ -43,34 +47,59 @@ public class SimpleBrickFragment extends BrickFragment {
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
 
-        bricks = new TextBrick[numberOfBricks];
+            ViewModelBrick[] bricks = new ViewModelBrick[numberOfBricks];
 
         for (int i = 0; i < numberOfBricks; i++) {
-            final int j = i;
-            bricks[i] = new TextBrick(
-                    new OrientationBrickSize(maxSpans()) {
-                        @Override
-                        protected int portrait() {
-                            return dataManager.getMaxSpanCount();
-                        }
+            final TextDataModel dataModel = new TextDataModel("Brick: " + i);
 
-                        @Override
-                        protected int landscape() {
-                            return HALF;
-                        }
-                    },
-                    new InnerOuterBrickPadding(5, 10),
-                    "Brick: " + i
-            );
+            new Timer().schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    dataModel.appendText(" Hello");
+                }
+
+            }, 0, 1000);
+
+            bricks[i] = new ViewModelBrick.Builder(R.layout.text_brick_vm)
+                    .setPadding(new InnerOuterBrickPadding(5, 10))
+                    .setSpanSize(
+                            new OrientationBrickSize(maxSpans()) {
+                                @Override
+                                protected int portrait() {
+                                    return dataManager.getMaxSpanCount();
+                                }
+
+                                @Override
+                                protected int landscape() {
+                                    return HALF;
+                                }
+                            }
+                    )
+                    .addViewModel(
+                            BR.textViewModel,
+                            new TextViewModel(dataModel)
+                    )
+                    .build();
+
             bricks[i].setOnDismiss(
-                    new Runnable() {
+                    new SwipeListener() {
                         @Override
-                        public void run() {
-                            Snackbar.make(
-                                    dataManager.getBrickRecyclerAdapter().getRecyclerView(),
-                                    "Deleted " + bricks[j].getText(),
-                                    Snackbar.LENGTH_SHORT
-                            ).show();
+                        public void swiped(int direction) {
+                            if (direction == ItemTouchHelper.RIGHT
+                                    || direction == ItemTouchHelper.END) {
+                                Snackbar.make(
+                                        dataManager.getBrickRecyclerAdapter().getRecyclerView(),
+                                        "Moved " + dataModel.getText(),
+                                        Snackbar.LENGTH_SHORT
+                                ).show();
+                            } else if (direction == ItemTouchHelper.LEFT
+                                    || direction == ItemTouchHelper.START) {
+                                Snackbar.make(
+                                        dataManager.getBrickRecyclerAdapter().getRecyclerView(),
+                                        "Deleted " + dataModel.getText(),
+                                        Snackbar.LENGTH_SHORT
+                                ).show();
+                            }
                         }
                     }
             );

--- a/BrickKit/app/src/main/res/layout/controller_brick_vm.xml
+++ b/BrickKit/app/src/main/res/layout/controller_brick_vm.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright © 2017 Wayfair. All rights reserved. -->
+<layout>
+    <data>
+        <variable
+            name="controllerViewModel"
+            type="com.wayfair.brickkitdemo.ControllerViewModel" />
+    </data>
+    <RelativeLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        android:gravity="center"
+        android:padding="@dimen/default_brick_content_padding">
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/text_input_layout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/text_input_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:inputType="number"
+                android:textColor="@color/colorAccent"
+                android:text="@{controllerViewModel.value}"
+                app:textChangedListener="@{controllerViewModel}"
+                tools:text="100" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <Button
+            android:id="@+id/down_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_toLeftOf="@+id/text_input_layout"
+            android:layout_toStartOf="@+id/text_input_layout"
+            android:background="@android:color/transparent"
+            android:text="@string/remove"
+            android:textColor="@color/colorAccent"
+            android:onClick="@{() -> controllerViewModel.remove()}"
+            app:srcCompat="@drawable/arrow_down_black"
+            tools:ignore="ContentDescription" />
+
+        <Button
+            android:id="@+id/up_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_toEndOf="@+id/text_input_layout"
+            android:layout_toRightOf="@+id/text_input_layout"
+            android:background="@android:color/transparent"
+            android:text="@string/add"
+            android:textColor="@color/colorAccent"
+            android:onClick="@{() -> controllerViewModel.add()}"
+            app:srcCompat="@drawable/arrow_up_black"
+            tools:ignore="ContentDescription" />
+    </RelativeLayout>
+</layout>

--- a/BrickKit/app/src/main/res/layout/used_brick_placeholder.xml
+++ b/BrickKit/app/src/main/res/layout/used_brick_placeholder.xml
@@ -8,7 +8,6 @@
     android:paddingBottom="24dp"
     android:paddingStart="@dimen/default_brick_content_padding"
     android:paddingEnd="@dimen/default_brick_content_padding"
-    app:base_alpha="0.7"
     app:intensity="0.2"
     app:auto_start="true">
 

--- a/BrickKit/bricks/build.gradle
+++ b/BrickKit/bricks/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'checkstyle'
 apply plugin: 'maven'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion '26.0.3'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -34,6 +34,7 @@ android {
     lintOptions {
         warningsAsErrors true
         abortOnError true
+        disable 'ObsoleteLintCustomCheck'
     }
 }
 
@@ -48,15 +49,15 @@ dependencies {
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
 
-    compile 'com.android.support:support-v4:25.1.0'
-    compile 'com.android.support:support-v13:25.1.0'
-    compile 'com.android.support:support-compat:25.1.0'
-    compile 'com.android.support:support-core-utils:25.1.0'
-    compile 'com.android.support:support-core-ui:25.1.0'
-    compile 'com.android.support:support-fragment:25.1.0'
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:support-v4:26.1.0'
+    compile 'com.android.support:support-v13:26.1.0'
+    compile 'com.android.support:support-compat:26.1.0'
+    compile 'com.android.support:support-core-utils:26.1.0'
+    compile 'com.android.support:support-core-ui:26.1.0'
+    compile 'com.android.support:support-fragment:26.1.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:recyclerview-v7:26.1.0'
+    compile 'com.android.support:design:26.1.0'
 
     testCompile 'junit:junit:4.12'
 }
@@ -75,23 +76,25 @@ def getCurrentVersion() {
     return "git describe --abbrev=0 --tag".execute().text.trim();
 }
 
-task createPom << {
-    pom {
-        project {
-            groupId 'com.wayfair'
-            artifactId 'brickkit-android'
-            version getCurrentVersion()
-            packaging 'aar'
+task createPom {
+    doLast {
+        pom {
+            project {
+                groupId 'com.wayfair'
+                artifactId 'brickkit-android'
+                version getCurrentVersion()
+                packaging 'aar'
 
-            licenses {
-                license {
-                    name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    distribution 'repo'
+                licenses {
+                    license {
+                        name 'The Apache Software License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution 'repo'
+                    }
                 }
             }
-        }
-    }.writeTo("build/brickkit-android-" + getCurrentVersion() + ".pom")
+        }.writeTo("build/brickkit-android-" + getCurrentVersion() + ".pom")
+    }
 }
 
 

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
@@ -141,6 +141,22 @@ public class BrickDataManagerTest {
     }
 
     @Test
+    public void testUpdateBricks() {
+        LinkedList<BaseBrick> bricks = new LinkedList<>(manager.getDataManagerItems());
+
+        bricks.addLast(brickTestHelper.generateBrick());
+        bricks.add(1, brickTestHelper.generateBrick());
+        bricks.add(3, brickTestHelper.generateBrick());
+
+        manager.updateBricks(bricks);
+
+        assertEquals(7, manager.getRecyclerViewItems().size());
+        assertEquals(7, manager.getDataManagerItems().size());
+
+        verify(headerBehavior).onDataSetChanged();
+    }
+
+    @Test
     public void testItemExist() {
         assertTrue(manager.hasInstanceOf(BaseBrick.class));
         manager.clear();

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
@@ -39,7 +39,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(AndroidJUnit4.class)
 public class BrickDataManagerTest {
+    private static final int STARTING_BRICKS = 4;
     private static final int MAX_SPANS = 8;
+    public static final String TAG = "Tag";
 
     private BrickDataManager manager;
     private BrickTestHelper.TestAdapterDataObserver observer;
@@ -58,10 +60,9 @@ public class BrickDataManagerTest {
         manager.setRecyclerView(context, new RecyclerView(context), GridLayoutManager.VERTICAL, false, parentView);
         brickTestHelper = new BrickTestHelper(context);
 
-        manager.addLast(brickTestHelper.generateBrick());
-        manager.addLast(brickTestHelper.generateBrick());
-        manager.addLast(brickTestHelper.generateBrick());
-        manager.addLast(brickTestHelper.generateBrick());
+        for (int i = 0; i < STARTING_BRICKS; i++) {
+            manager.addLast(brickTestHelper.generateBrick());
+        }
 
         footerBehavior = mock(StickyFooterBehavior.class);
         manager.addBehavior(footerBehavior);
@@ -1274,5 +1275,89 @@ public class BrickDataManagerTest {
         assertTrue(manager.getRecyclerView().getLayoutManager() instanceof StaggeredGridLayoutManager);
         assertFalse(manager.getRecyclerView().getLayoutManager().isItemPrefetchEnabled());
         assertFalse(manager.getRecyclerView().getLayoutManager().supportsPredictiveItemAnimations());
+    }
+
+    @Test
+    public void testAddToTagCache() {
+        BaseBrick baseBrick = brickTestHelper.generateBrick();
+        baseBrick.setTag(TAG);
+        manager.addLast(baseBrick);
+
+        assertEquals(1, manager.getBricksByTag(TAG).size());
+    }
+
+    @Test
+    public void testAddMultipleToTagCache() {
+        BaseBrick baseBrick = brickTestHelper.generateBrick();
+        baseBrick.setTag(TAG);
+        manager.addLast(baseBrick);
+
+        BaseBrick baseBrick2 = brickTestHelper.generateBrick();
+        baseBrick.setTag(TAG);
+        manager.addLast(baseBrick2);
+
+        assertEquals(2, manager.getBricksByTag(TAG).size());
+    }
+
+    @Test
+    public void testAddNullToTagCache() {
+        BaseBrick baseBrick = brickTestHelper.generateBrick();
+        baseBrick.setTag(TAG);
+        manager.addLast(baseBrick);
+        baseBrick.setTag(null);
+
+        assertNull(manager.getBricksByTag(TAG));
+    }
+
+    @Test
+    public void testRemoveFromTagCache() {
+        BaseBrick baseBrick = brickTestHelper.generateBrick();
+        baseBrick.setTag(TAG);
+        manager.addLast(baseBrick);
+
+        assertEquals(1, manager.getBricksByTag(TAG).size());
+
+        manager.removeAllByTag(TAG);
+
+        assertNull(manager.getBricksByTag(TAG));
+    }
+
+    @Test
+    public void testAddToLayoutIdCache() {
+        BaseBrick baseBrick = brickTestHelper.generateBrick();
+        manager.addLast(baseBrick);
+
+        assertEquals(STARTING_BRICKS + 1, manager.getBricksByLayoutId(baseBrick.getLayout()).size());
+    }
+
+    @Test
+    public void testAddMultipleToLayoutIdCache() {
+        BaseBrick baseBrick = brickTestHelper.generateBrick();
+        manager.addLast(baseBrick);
+
+        BaseBrick baseBrick2 = brickTestHelper.generateBrick();
+        manager.addLast(baseBrick2);
+
+        assertEquals(STARTING_BRICKS + 2, manager.getBricksByLayoutId(baseBrick.getLayout()).size());
+    }
+
+    @Test
+    public void testAddNullToLayoutIdCache() {
+        BaseBrick baseBrick = brickTestHelper.generateBrick();
+        manager.addLast(baseBrick);
+
+        assertNull(manager.getBricksByLayoutId(-1));
+    }
+
+    @Test
+    public void testRemoveFromLayoutIdCache() {
+        BaseBrick baseBrick = brickTestHelper.generateBrick();
+        manager.addLast(baseBrick);
+
+        assertEquals(STARTING_BRICKS + 1, manager.getBricksByLayoutId(baseBrick.getLayout()).size());
+
+        manager.removeAllByLayoutId(baseBrick.getLayout());
+
+        assertNull(manager.getBricksByLayoutId(baseBrick.getLayout()));
     }
 }

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickItemTouchHelperCallbackTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickItemTouchHelperCallbackTest.java
@@ -129,6 +129,6 @@ public class BrickItemTouchHelperCallbackTest {
         callback.onSwiped(viewHolder, DIRECTION);
 
         verify(dataManager).removeItem(brick);
-        verify(brick).dismissed();
+        verify(brick).dismissed(DIRECTION);
     }
 }

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/BaseBrickTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/BaseBrickTest.java
@@ -6,6 +6,7 @@ package com.wayfair.brickkit.brick;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.View;
 
 import com.wayfair.brickkit.BrickDataManager;
@@ -155,7 +156,7 @@ public class BaseBrickTest {
     public void testDismissed() {
         TestBaseBrick brick = new TestBaseBrick(context, brickSize);
 
-        brick.dismissed();
+        brick.dismissed(ItemTouchHelper.UP);
 
         // nothing to verify
     }

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/TextBrickTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/TextBrickTest.java
@@ -6,6 +6,7 @@ package com.wayfair.brickkit.brick;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.helper.ItemTouchHelper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -66,11 +67,11 @@ public class TextBrickTest {
 
         TextBrick brick = new TextBrick(brickSize, TEXT);
 
-        brick.dismissed();
+        brick.dismissed(ItemTouchHelper.START);
 
         brick.setOnDismiss(runnable);
 
-        brick.dismissed();
+        brick.dismissed(ItemTouchHelper.START);
 
         verify(runnable).run();
     }

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/ViewModelBrickTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/ViewModelBrickTest.java
@@ -1,11 +1,10 @@
 package com.wayfair.brickkit.brick;
 
 import android.content.Context;
-import android.databinding.DataBindingUtil;
-import android.databinding.ViewDataBinding;
+import android.os.Handler;
+import android.os.Looper;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.annotation.UiThreadTest;
-import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.v7.widget.helper.ItemTouchHelper;
 import android.util.SparseArray;
@@ -15,23 +14,19 @@ import android.widget.LinearLayout;
 
 import com.wayfair.brickkit.BR;
 import com.wayfair.brickkit.R;
-import com.wayfair.brickkit.databinding.TextBrickVmBinding;
 import com.wayfair.brickkit.models.TextDataModel;
 import com.wayfair.brickkit.models.TextViewModel;
 import com.wayfair.brickkit.padding.BrickPadding;
 import com.wayfair.brickkit.size.BrickSize;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.matchers.Not;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class ViewModelBrickTest {
@@ -44,9 +39,6 @@ public class ViewModelBrickTest {
     private BrickSize brickSize;
     private BrickPadding brickPadding;
 
-    @Rule
-    public UiThreadTestRule uiThreadTestRule = new UiThreadTestRule();
-
     @Before
     public void setup() {
         context = InstrumentationRegistry.getTargetContext();
@@ -55,8 +47,9 @@ public class ViewModelBrickTest {
     }
 
     @Test
+    @UiThreadTest
     public void ViewModelBrick_SingleViewModel_Test() {
-        uiThreadTestRule.runOnUiThread(
+        new Handler(Looper.getMainLooper()).post(
                 new Runnable() {
                     @Override
                     public void run() {
@@ -86,8 +79,9 @@ public class ViewModelBrickTest {
     }
 
     @Test
+    @UiThreadTest
     public void ViewModelBrick_MultiViewModel_Test() {
-        uiThreadTestRule.runOnUiThread(
+        new Handler(Looper.getMainLooper()).post(
                 new Runnable() {
                     @Override
                     public void run() {
@@ -119,8 +113,9 @@ public class ViewModelBrickTest {
     }
 
     @Test
+    @UiThreadTest
     public void ViewModelBrick_Dismissed_Test() {
-        uiThreadTestRule.runOnUiThread(
+        new Handler(Looper.getMainLooper()).post(
                 new Runnable() {
                     @Override
                     public void run() {
@@ -154,8 +149,9 @@ public class ViewModelBrickTest {
     }
 
     @Test
+    @UiThreadTest
     public void ViewModelBrick_Dismissed_NotSet_Test() {
-        uiThreadTestRule.runOnUiThread(
+        new Handler(Looper.getMainLooper()).post(
                 new Runnable() {
                     @Override
                     public void run() {

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/ViewModelBrickTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/ViewModelBrickTest.java
@@ -119,13 +119,11 @@ public class ViewModelBrickTest {
                         TextDataModel textDataModel = new TextDataModel(TEXT);
                         TextViewModel textViewModel = spy(new TextViewModel(textDataModel));
 
-                        ViewModelBrick viewModelBrick = new ViewModelBrick(
-                                brickSize,
-                                brickPadding,
-                                LAYOUT_ID,
-                                BIND_ID,
-                                textViewModel
-                        );
+                        ViewModelBrick viewModelBrick = new ViewModelBrick.Builder(LAYOUT_ID)
+                                .setSpanSize(brickSize)
+                                .setPadding(brickPadding)
+                                .addViewModel(BIND_ID, textViewModel)
+                                .build();
 
                         SwipeListener swipeListener = mock(SwipeListener.class);
 
@@ -154,13 +152,11 @@ public class ViewModelBrickTest {
                         TextDataModel textDataModel = new TextDataModel(TEXT);
                         TextViewModel textViewModel = spy(new TextViewModel(textDataModel));
 
-                        ViewModelBrick viewModelBrick = new ViewModelBrick(
-                                brickSize,
-                                brickPadding,
-                                LAYOUT_ID,
-                                BIND_ID,
-                                textViewModel
-                        );
+                        ViewModelBrick viewModelBrick = new ViewModelBrick.Builder(LAYOUT_ID)
+                                .setSpanSize(brickSize)
+                                .setPadding(brickPadding)
+                                .addViewModel(BIND_ID, textViewModel)
+                                .build();
 
                         SwipeListener swipeListener = mock(SwipeListener.class);
 
@@ -195,12 +191,11 @@ public class ViewModelBrickTest {
         SparseArray<ViewModel> viewModelSparseArray = new SparseArray<>();
         viewModelSparseArray.put(BIND_ID, textViewModel);
         viewModelBrick.setViewModels(viewModelSparseArray);
-        ViewModelBrick viewModelBrick2 = new ViewModelBrick(
-                brickSize,
-                brickPadding,
-                LAYOUT_ID,
-                viewModelSparseArray
-        );
+        ViewModelBrick viewModelBrick2 = new ViewModelBrick.Builder(LAYOUT_ID)
+                .setSpanSize(brickSize)
+                .setPadding(brickPadding)
+                .setViewModels(viewModelSparseArray)
+                .build();
 
         Assert.assertTrue(viewModelBrick.equals(viewModelBrick2));
     }
@@ -219,13 +214,12 @@ public class ViewModelBrickTest {
         TextDataModel textDataModel2 = new TextDataModel(TEXT_2);
         TextViewModel textViewModel2 = spy(new TextViewModel(textDataModel2));
 
-        ViewModelBrick viewModelBrick2 = new ViewModelBrick(
-                brickSize,
-                brickPadding,
-                LAYOUT_ID,
-                BIND_ID,
-                textViewModel2
-        );
+
+        ViewModelBrick viewModelBrick2 = new ViewModelBrick.Builder(LAYOUT_ID)
+                .setSpanSize(brickSize)
+                .setPadding(brickPadding)
+                .addViewModel(BIND_ID, textViewModel2)
+                .build();
 
 
         Assert.assertFalse(viewModelBrick.equals(viewModelBrick2));

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/ViewModelBrickTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/ViewModelBrickTest.java
@@ -1,0 +1,192 @@
+package com.wayfair.brickkit.brick;
+
+import android.content.Context;
+import android.databinding.DataBindingUtil;
+import android.databinding.ViewDataBinding;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.rule.UiThreadTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.helper.ItemTouchHelper;
+import android.util.SparseArray;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import com.wayfair.brickkit.BR;
+import com.wayfair.brickkit.R;
+import com.wayfair.brickkit.databinding.TextBrickVmBinding;
+import com.wayfair.brickkit.models.TextDataModel;
+import com.wayfair.brickkit.models.TextViewModel;
+import com.wayfair.brickkit.padding.BrickPadding;
+import com.wayfair.brickkit.size.BrickSize;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.internal.matchers.Not;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class ViewModelBrickTest {
+    private final String TEXT = "Test Text...";
+    private final String APPENDING_TEXT = " DONE";
+    private final int LAYOUT_ID = R.layout.text_brick_vm;
+    private final int BIND_ID = BR.textViewModel;
+
+    private Context context;
+    private BrickSize brickSize;
+    private BrickPadding brickPadding;
+
+    @Rule
+    public UiThreadTestRule uiThreadTestRule = new UiThreadTestRule();
+
+    @Before
+    public void setup() {
+        context = InstrumentationRegistry.getTargetContext();
+        brickSize = mock(BrickSize.class);
+        brickPadding = mock(BrickPadding.class);
+    }
+
+    @Test
+    public void ViewModelBrick_SingleViewModel_Test() {
+        uiThreadTestRule.runOnUiThread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        TextDataModel textDataModel = new TextDataModel(TEXT);
+                        TextViewModel textViewModel = spy(new TextViewModel(textDataModel));
+
+                        ViewModelBrick viewModelBrick = new ViewModelBrick(
+                                brickSize,
+                                brickPadding,
+                                LAYOUT_ID,
+                                BIND_ID,
+                                textViewModel
+                        );
+
+                        LinearLayout parent = new LinearLayout(context);
+                        View itemView = LayoutInflater.from(parent.getContext()).inflate(viewModelBrick.getLayout(), parent, false);
+
+                        ViewModelBrick.ViewModelBrickViewHolder holder = (ViewModelBrick.ViewModelBrickViewHolder) viewModelBrick.createViewHolder(itemView);
+                        viewModelBrick.onBindData(holder);
+
+                        textDataModel.appendText(APPENDING_TEXT);
+
+                        verify((TextViewModel) viewModelBrick.getViewModel(BIND_ID)).getText();
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void ViewModelBrick_MultiViewModel_Test() {
+        uiThreadTestRule.runOnUiThread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        TextDataModel textDataModel = new TextDataModel(TEXT);
+                        TextViewModel textViewModel = spy(new TextViewModel(textDataModel));
+
+                        SparseArray<ViewModel> viewModels = new SparseArray<>();
+                        viewModels.put(BIND_ID, textViewModel);
+
+                        ViewModelBrick viewModelBrick = new ViewModelBrick(
+                                brickSize,
+                                brickPadding,
+                                LAYOUT_ID,
+                                viewModels
+                        );
+
+                        LinearLayout parent = new LinearLayout(context);
+                        View itemView = LayoutInflater.from(parent.getContext()).inflate(viewModelBrick.getLayout(), parent, false);
+
+                        ViewModelBrick.ViewModelBrickViewHolder holder = (ViewModelBrick.ViewModelBrickViewHolder) viewModelBrick.createViewHolder(itemView);
+                        viewModelBrick.onBindData(holder);
+
+                        textDataModel.appendText(APPENDING_TEXT);
+
+                        verify((TextViewModel) viewModelBrick.getViewModel(BIND_ID)).getText();
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void ViewModelBrick_Dismissed_Test() {
+        uiThreadTestRule.runOnUiThread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        TextDataModel textDataModel = new TextDataModel(TEXT);
+                        TextViewModel textViewModel = spy(new TextViewModel(textDataModel));
+
+                        ViewModelBrick viewModelBrick = new ViewModelBrick(
+                                brickSize,
+                                brickPadding,
+                                LAYOUT_ID,
+                                BIND_ID,
+                                textViewModel
+                        );
+
+                        SwipeListener swipeListener = mock(SwipeListener.class);
+
+                        viewModelBrick.setOnDismiss(swipeListener);
+
+                        LinearLayout parent = new LinearLayout(context);
+                        View itemView = LayoutInflater.from(parent.getContext()).inflate(viewModelBrick.getLayout(), parent, false);
+
+                        ViewModelBrick.ViewModelBrickViewHolder holder = (ViewModelBrick.ViewModelBrickViewHolder) viewModelBrick.createViewHolder(itemView);
+                        viewModelBrick.onBindData(holder);
+
+                        viewModelBrick.dismissed(ItemTouchHelper.RIGHT);
+
+                        verify(swipeListener).swiped(ItemTouchHelper.RIGHT);
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void ViewModelBrick_Dismissed_NotSet_Test() {
+        uiThreadTestRule.runOnUiThread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        TextDataModel textDataModel = new TextDataModel(TEXT);
+                        TextViewModel textViewModel = spy(new TextViewModel(textDataModel));
+
+                        ViewModelBrick viewModelBrick = new ViewModelBrick(
+                                brickSize,
+                                brickPadding,
+                                LAYOUT_ID,
+                                BIND_ID,
+                                textViewModel
+                        );
+
+                        SwipeListener swipeListener = mock(SwipeListener.class);
+
+                        viewModelBrick.setOnDismiss(swipeListener);
+                        viewModelBrick.setOnDismiss(null);
+
+                        LinearLayout parent = new LinearLayout(context);
+                        View itemView = LayoutInflater.from(parent.getContext()).inflate(viewModelBrick.getLayout(), parent, false);
+
+                        ViewModelBrick.ViewModelBrickViewHolder holder = (ViewModelBrick.ViewModelBrickViewHolder) viewModelBrick.createViewHolder(itemView);
+                        viewModelBrick.onBindData(holder);
+
+                        viewModelBrick.dismissed(ItemTouchHelper.RIGHT);
+
+                        verify(swipeListener, never()).swiped(ItemTouchHelper.RIGHT);
+                    }
+                }
+        );
+    }
+
+}

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -235,7 +235,7 @@ public class BrickDataManager implements Serializable {
      *
      * @param bricks the new list of bricks.
      */
-    public void diffUpdateViewModelBricks(LinkedList<BaseBrick> bricks) {
+    public void updateBricks(LinkedList<BaseBrick> bricks) {
         LinkedList<BaseBrick> newVisibleBricks = new LinkedList<>();
 
         for (BaseBrick brick : bricks) {

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -3,6 +3,7 @@ package com.wayfair.brickkit;
 import android.content.Context;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
+import android.support.v7.util.DiffUtil;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.StaggeredGridLayoutManager;
@@ -227,6 +228,26 @@ public class BrickDataManager implements Serializable {
         }
 
         return currentlyVisibleItems;
+    }
+
+    /**
+     * Use DiffUtils to update the recycler view.
+     *
+     * @param bricks the new list of bricks.
+     */
+    public void diffUpdateViewModelBricks(LinkedList<BaseBrick> bricks) {
+        LinkedList<BaseBrick> newVisibleBricks = new LinkedList<>();
+
+        for (BaseBrick brick : bricks) {
+            if (!brick.isHidden()) {
+                newVisibleBricks.add(brick);
+            }
+        }
+        DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(new BrickDiffUtilCallback(currentlyVisibleItems, newVisibleBricks));
+        items.clear();
+        items.addAll(bricks);
+        dataHasChanged();
+        diffResult.dispatchUpdatesTo(brickRecyclerAdapter);
     }
 
     /**

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDiffUtilCallback.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDiffUtilCallback.java
@@ -7,7 +7,7 @@ import com.wayfair.brickkit.brick.BaseBrick;
 import java.util.LinkedList;
 
 /**
- * A DuffUtil for Bricks.
+ * A DiffUtil for Bricks.
  */
 public class BrickDiffUtilCallback extends DiffUtil.Callback {
 

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDiffUtilCallback.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDiffUtilCallback.java
@@ -1,0 +1,47 @@
+package com.wayfair.brickkit;
+
+import android.support.v7.util.DiffUtil;
+
+import com.wayfair.brickkit.brick.BaseBrick;
+
+import java.util.LinkedList;
+
+/**
+ * A DuffUtil for Bricks.
+ */
+public class BrickDiffUtilCallback extends DiffUtil.Callback {
+
+    private LinkedList<BaseBrick> oldList;
+    private LinkedList<BaseBrick> newList;
+
+    /**
+     * Constructor.
+     *
+     * @param oldList the old list (usually the one in the {@link BrickDataManager}
+     * @param newList the new list
+     */
+    BrickDiffUtilCallback(LinkedList<BaseBrick> oldList, LinkedList<BaseBrick> newList) {
+        this.oldList = oldList;
+        this.newList = newList;
+    }
+
+    @Override
+    public int getOldListSize() {
+        return oldList.size();
+    }
+
+    @Override
+    public int getNewListSize() {
+        return newList.size();
+    }
+
+    @Override
+    public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+        return oldList.get(oldItemPosition).getLayout() == newList.get(newItemPosition).getLayout();
+    }
+
+    @Override
+    public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+        return oldList.get(oldItemPosition).equals(newList.get(newItemPosition));
+    }
+}

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickFragment.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickFragment.java
@@ -16,6 +16,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.wayfair.brickkit.brick.BaseBrick;
+
 /**
  * Fragment which provides a simple interface for adding bricks / behaviors.
  */
@@ -52,7 +54,7 @@ public abstract class BrickFragment extends Fragment {
      * @return the max spans for this fragment.
      */
     public int maxSpans() {
-        return 240;
+        return BaseBrick.DEFAULT_MAX_SPAN_COUNT;
     }
 
     /**

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickItemTouchHelperCallback.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickItemTouchHelperCallback.java
@@ -74,6 +74,6 @@ class BrickItemTouchHelperCallback extends ItemTouchHelper.Callback {
     public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
         BaseBrick brick = dataManager.brickAtPosition(viewHolder.getAdapterPosition());
         dataManager.removeItem(brick);
-        brick.dismissed();
+        brick.dismissed(direction);
     }
 }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
@@ -13,14 +13,26 @@ import com.wayfair.brickkit.StickyScrollMode;
 import com.wayfair.brickkit.padding.BrickPadding;
 import com.wayfair.brickkit.padding.SimpleBrickPadding;
 import com.wayfair.brickkit.size.BrickSize;
+import com.wayfair.brickkit.size.SimpleBrickSize;
 
 /**
  * Abstract class which defines Bricks.
  */
 public abstract class BaseBrick {
+    public static final int DEFAULT_MAX_SPAN_COUNT = 240;
+
+    public final static BrickSize DEFAULT_SIZE_FULL_WIDTH = new SimpleBrickSize(DEFAULT_MAX_SPAN_COUNT) {
+        @Override
+        protected int size() {
+            return DEFAULT_MAX_SPAN_COUNT;
+        }
+    };
+    public final static BrickPadding DEFAULT_PADDING_NONE = new SimpleBrickPadding(0);
+
     private final BrickPadding padding;
     private final BrickSize spanSize;
 
+    private Object tag;
     private boolean hidden = false;
     private boolean header = false;
     private boolean footer = false;
@@ -31,6 +43,13 @@ public abstract class BaseBrick {
     @StickyScrollMode
     private int stickyScrollMode = StickyScrollMode.SHOW_ON_SCROLL;
     private BrickDataManager dataManager;
+
+    /**
+     * Constructor.
+     */
+    public BaseBrick() {
+        this(DEFAULT_SIZE_FULL_WIDTH, DEFAULT_PADDING_NONE);
+    }
 
     /**
      * Constructor.
@@ -50,9 +69,16 @@ public abstract class BaseBrick {
      * @param spanSize size information for this brick
      */
     public BaseBrick(BrickSize spanSize) {
-        this.spanSize = spanSize;
-        this.spanSize.setBaseBrick(this);
-        this.padding = new SimpleBrickPadding(0);
+        this(spanSize, DEFAULT_PADDING_NONE);
+    }
+
+    /**
+     * Constructor which uses the default padding.
+     *
+     * @param padding  padding for this brick
+     */
+    public BaseBrick(BrickPadding padding) {
+        this(DEFAULT_SIZE_FULL_WIDTH, padding);
     }
 
     /**
@@ -100,6 +126,32 @@ public abstract class BaseBrick {
     public int getPlaceholderLayout() {
         throw new UnsupportedOperationException(getClass().getSimpleName()
                 + " getPlaceholderLayout() method must be overridden within brick extending BaseBrick");
+    }
+
+    /**
+     * Set the brick's tag. This is similar to a {@link View#setTag(Object)}.
+     *
+     * @param tag Set the tag that can be used to ID the brick later
+     */
+    public void setTag(Object tag) {
+        if (dataManager != null && this.tag != null && !this.tag.equals(tag)) {
+            dataManager.removeFromTagCache(this);
+        }
+
+        this.tag = tag;
+
+        if (dataManager != null && tag != null) {
+            dataManager.addToTagCache(this);
+        }
+    }
+
+    /**
+     * Get's the brick's tag. This is similar to a {@link View#getTag()}.
+     *
+     * @return The tag for the brick
+     */
+    public Object getTag() {
+        return tag;
     }
 
     /**
@@ -310,8 +362,13 @@ public abstract class BaseBrick {
 
     /**
      * Called when an item is swiped-to-dismiss.
+     *
+     * @param direction one of {@link ItemTouchHelper.UP}, {@link ItemTouchHelper.RIGHT},
+     *                  {@link ItemTouchHelper.DOWN}, {@link ItemTouchHelper.LEFT},
+     *                  {@link ItemTouchHelper.START}, {@link ItemTouchHelper.END}
+     *
      */
-    public void dismissed() {
+    public void dismissed(int direction) {
     }
 
     /**

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
@@ -21,13 +21,13 @@ import com.wayfair.brickkit.size.SimpleBrickSize;
 public abstract class BaseBrick {
     public static final int DEFAULT_MAX_SPAN_COUNT = 240;
 
-    public final static BrickSize DEFAULT_SIZE_FULL_WIDTH = new SimpleBrickSize(DEFAULT_MAX_SPAN_COUNT) {
+    public static final BrickSize DEFAULT_SIZE_FULL_WIDTH = new SimpleBrickSize(DEFAULT_MAX_SPAN_COUNT) {
         @Override
         protected int size() {
             return DEFAULT_MAX_SPAN_COUNT;
         }
     };
-    public final static BrickPadding DEFAULT_PADDING_NONE = new SimpleBrickPadding(0);
+    public static final BrickPadding DEFAULT_PADDING_NONE = new SimpleBrickPadding(0);
 
     private final BrickPadding padding;
     private final BrickSize spanSize;

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/DataModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/DataModel.java
@@ -1,0 +1,71 @@
+package com.wayfair.brickkit.brick;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.support.v4.util.ArraySet;
+
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * An abstract class that all Data Models should be based on. This is use tightly
+ * with {@link ViewModel}s and will automatically notify update listeners
+ * when {@link #notifyChange()} is called.
+ */
+public abstract class DataModel implements Serializable {
+    protected final Set<DataModelUpdateListener> updateListeners = new ArraySet<>();
+
+    /**
+     * Add an {@link DataModelUpdateListener} to the list of listeners.
+     *
+     * @param updateListener the listener to add
+     */
+    public void addUpdateListener(DataModelUpdateListener updateListener) {
+        updateListeners.add(updateListener);
+    }
+
+    /**
+     * Remove a {@link DataModelUpdateListener} to the list of listeners.
+     *
+     * @param updateListener the listener to remove
+     */
+    public void removeUpdateListener(DataModelUpdateListener updateListener) {
+        updateListeners.remove(updateListener);
+    }
+
+    /**
+     * This function is called when you are ready to notify listeners that the data has changed.
+     */
+    public void notifyChange() {
+        for (final DataModelUpdateListener updateListener : updateListeners) {
+            new Handler(Looper.getMainLooper()).post(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            updateListener.notifyChange();
+                        }
+                    }
+            );
+        }
+    }
+
+    /**
+     * Determines if the DataModel is ready to be processed by a {@link ViewModel}.
+     *
+     * @return true if the data is ready, defaults to true
+     */
+    public boolean isReady() {
+        return true;
+    }
+
+    /**
+     * The interface required to be implemented oin order to listen for changes
+     * on {@link DataModel}s.
+     */
+    public interface DataModelUpdateListener {
+        /**
+         * Should handle updating whatever is listening to a {@link DataModel}.
+         */
+        void notifyChange();
+    }
+}

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/SwipeListener.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/SwipeListener.java
@@ -1,0 +1,20 @@
+package com.wayfair.brickkit.brick;
+
+/**
+ * An interface for handling swipes on a {@link BaseBrick}.
+ */
+public interface SwipeListener {
+
+    /**
+     * Called when an item is swiped-to-dismiss.
+     *
+     * @param direction one of {@link android.support.v7.widget.helper.ItemTouchHelper.UP},
+     *                  {@link android.support.v7.widget.helper.ItemTouchHelper.RIGHT},
+     *                  {@link android.support.v7.widget.helper.ItemTouchHelper.DOWN},
+     *                  {@link android.support.v7.widget.helper.ItemTouchHelper.LEFT},
+     *                  {@link android.support.v7.widget.helper.ItemTouchHelper.START},
+     *                  {@link android.support.v7.widget.helper.ItemTouchHelper.END}
+     *
+     */
+    void swiped(int direction);
+}

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/TextBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/TextBrick.java
@@ -58,7 +58,7 @@ public class TextBrick extends BaseBrick {
     }
 
     @Override
-    public void dismissed() {
+    public void dismissed(int direction) {
         if (onDismiss != null) {
             onDismiss.run();
         }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
@@ -25,6 +25,11 @@ public abstract class ViewModel<DM extends DataModel> extends BaseObservable imp
         setDataModel(dataModel);
     }
 
+    /**
+     * Add an {@link ViewModelUpdateListener} to the list of items watching for changes
+     *
+     * @param updateListener the object that is watching
+     */
     public void addUpdateListener(ViewModelUpdateListener updateListener) {
         updateListeners.add(updateListener);
     }
@@ -71,7 +76,13 @@ public abstract class ViewModel<DM extends DataModel> extends BaseObservable imp
         return dataModel != null && dataModel.isReady();
     }
 
+    /**
+     * Interface for listening to changes
+     */
     public interface ViewModelUpdateListener {
+        /**
+         * Called when notify change is called
+         */
         void onChange();
     }
 }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
@@ -26,7 +26,7 @@ public abstract class ViewModel<DM extends DataModel> extends BaseObservable imp
     }
 
     /**
-     * Add an {@link ViewModelUpdateListener} to the list of items watching for changes
+     * Add an {@link ViewModelUpdateListener} to the list of items watching for changes.
      *
      * @param updateListener the object that is watching
      */
@@ -68,7 +68,7 @@ public abstract class ViewModel<DM extends DataModel> extends BaseObservable imp
     }
 
     /**
-     * Determines if the {@link DataModel} is ready, meaning the ViewModel is ready
+     * Determines if the {@link DataModel} is ready, meaning the ViewModel is ready.
      *
      * @return if the data model is ready, IE fully populated
      */
@@ -77,11 +77,11 @@ public abstract class ViewModel<DM extends DataModel> extends BaseObservable imp
     }
 
     /**
-     * Interface for listening to changes
+     * Interface for listening to changes.
      */
     public interface ViewModelUpdateListener {
         /**
-         * Called when notify change is called
+         * Called when notify change is called.
          */
         void onChange();
     }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
@@ -1,0 +1,77 @@
+package com.wayfair.brickkit.brick;
+
+import android.databinding.BaseObservable;
+import android.support.annotation.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The object used to bind information in a {@link ViewModelBrick}.
+ *
+ * @param <DM> the {@link DataModel} type that drives this
+ */
+public abstract class ViewModel<DM extends DataModel> extends BaseObservable implements DataModel.DataModelUpdateListener {
+    protected DM dataModel;
+    protected final Set<ViewModelUpdateListener> updateListeners = new HashSet<>();
+
+    /**
+     * Constructor. Automatically gets tied to the {@link DataModel} as
+     * a {@link com.wayfair.brickkit.brick.DataModel.DataModelUpdateListener}.
+     *
+     * @param dataModel the data model that is used to create the ViewModel
+     */
+    public ViewModel(@Nullable DM dataModel) {
+        setDataModel(dataModel);
+    }
+
+    public void addUpdateListener(ViewModelUpdateListener updateListener) {
+        updateListeners.add(updateListener);
+    }
+
+    @Override
+    public void notifyChange() {
+        for (ViewModelUpdateListener updateListener : updateListeners) {
+            updateListener.onChange();
+        }
+    }
+
+    /**
+     * Gets the underlying {@link DataModel}.
+     *
+     * @return the {@link DataModel}
+     */
+    public DM getDataModel() {
+        return dataModel;
+    }
+
+    /**
+     * Sets the underlying {@link DataModel}.
+     *
+     * @param dataModel the new {@link DataModel}
+     */
+    public void setDataModel(DM dataModel) {
+        if (dataModel == null && this.dataModel != null) {
+            this.dataModel.removeUpdateListener(this);
+        }
+
+        this.dataModel = dataModel;
+
+        if (dataModel != null) {
+            this.dataModel.addUpdateListener(this);
+        }
+    }
+
+    /**
+     * Determines if the {@link DataModel} is ready, meaning the ViewModel is ready
+     *
+     * @return if the data model is ready, IE fully populated
+     */
+    public boolean isDataModelReady() {
+        return dataModel != null && dataModel.isReady();
+    }
+
+    public interface ViewModelUpdateListener {
+        void onChange();
+    }
+}

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
@@ -1,0 +1,356 @@
+package com.wayfair.brickkit.brick;
+
+import android.databinding.DataBindingUtil;
+import android.databinding.ViewDataBinding;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.util.SparseArray;
+import android.view.View;
+
+import com.wayfair.brickkit.BrickViewHolder;
+import com.wayfair.brickkit.padding.BrickPadding;
+import com.wayfair.brickkit.size.BrickSize;
+
+/**
+ * This class is used as a Generic Brick that can take in any XML Layout and use DataBinding to
+ * insert information from a {@link ViewModel}.
+ */
+public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpdateListener {
+    @LayoutRes
+    private final int layoutId;
+    protected final SparseArray<ViewModel> viewModels;
+
+    protected SwipeListener onDismiss;
+
+    /**
+     * Constructor for setting up a ViewModelBrick with only one {@link ViewModel}.
+     *
+     * @param spanSize size information for this brick
+     * @param padding padding for this brick
+     * @param layoutId the id {@link LayoutRes} for the XML
+     * @param bindId the id generated for the "variable" from {@link ViewDataBinding}
+     * @param viewModel the {@link ViewModel} to bind the the XML
+     */
+    ViewModelBrick(BrickSize spanSize, BrickPadding padding,
+                          @LayoutRes int layoutId, int bindId, ViewModel viewModel) {
+        super(spanSize, padding);
+
+        this.layoutId = layoutId;
+        this.viewModels = new SparseArray<>();
+        this.viewModels.put(bindId, viewModel);
+
+        for (int i = 0; i < viewModels.size(); i++) {
+            viewModels.valueAt(i).addUpdateListener(this);
+        }
+    }
+
+
+    /**
+     * Constructor for setting up a ViewModelBrick with only one {@link ViewModel}.
+     *
+     * @param spanSize size information for this brick
+     * @param padding padding for this brick
+     * @param layoutId the id {@link LayoutRes} for the XML
+     * @param viewModels the {@link ViewModel}s and ids generated for the "variable"
+     *                   from {@link ViewDataBinding} to bind the the XML
+     */
+    ViewModelBrick(BrickSize spanSize, BrickPadding padding,
+                          @LayoutRes int layoutId, SparseArray<ViewModel> viewModels) {
+        super(spanSize, padding);
+
+        this.layoutId = layoutId;
+        this.viewModels = viewModels;
+
+        for (int i = 0; i < viewModels.size(); i++) {
+            viewModels.valueAt(i).addUpdateListener(this);
+        }
+    }
+
+    /**
+     * Private constructor that the {@link Builder} class uses
+     *
+     * @param builder the builder
+     */
+    private ViewModelBrick(Builder builder) {
+        super(builder.spanSize, builder.padding);
+
+        this.layoutId = builder.layoutId;
+        this.onDismiss = builder.onDismiss;
+        this.viewModels = builder.viewModels;
+
+        for (int i = 0; i < viewModels.size(); i++) {
+            viewModels.valueAt(i).addUpdateListener(this);
+        }
+    }
+
+    /**
+     * A builder class for {@link ViewModelBrick}, this makes it clearer what is required and what you are actually doing when creating
+     * {@link ViewModelBrick}s.
+     */
+    public static class Builder {
+        @LayoutRes
+        int layoutId;
+        SparseArray<ViewModel> viewModels = new SparseArray<>();
+        BrickSize spanSize = getDefaultSize();
+        BrickPadding padding = getDefaultPadding();
+        SwipeListener onDismiss = null;
+
+        /**
+         * Builder constructor, requires only a {@link LayoutRes} to work.
+         *
+         * @param layoutId a {@link LayoutRes} to use as a brick
+         */
+        public Builder(@LayoutRes int layoutId) {
+            this.layoutId = layoutId;
+        }
+
+        /**
+         * Add a {@link ViewModel} with a binding Id for the layout already defined.
+         *
+         * @param bindingId the binding Id of the view model
+         * @param viewModel the view model to be bound, extends {@link ViewModel}
+         * @return the builder
+         */
+        public Builder addViewModel(int bindingId, ViewModel viewModel) {
+            if (viewModel != null) {
+                this.viewModels.put(bindingId, viewModel);
+            }
+            return this;
+        }
+
+        /**
+         * Add a set of {@link ViewModel}s and their binding Ids.
+         *
+         * @param viewModels a {@link SparseArray} of binding Ids and {@link ViewModel}s
+         * @return the builder
+         */
+        public Builder setViewModels(SparseArray<ViewModel> viewModels) {
+            this.viewModels = viewModels;
+            return this;
+        }
+
+        /**
+         * Set the {@link BrickSize}
+         *
+         * @param spanSize the {@link BrickSize}
+         * @return the builder
+         */
+        public Builder setSpanSize(BrickSize spanSize) {
+            this.spanSize = spanSize;
+            return this;
+        }
+
+        /**
+         * Set the {@link BrickPadding}
+         *
+         * @param padding the {@link BrickPadding}
+         * @return the builder
+         */
+        public Builder setPadding(BrickPadding padding) {
+            this.padding = padding;
+            return this;
+        }
+
+        /**
+         * Set the {@link SwipeListener}
+         *
+         * @param onDismiss the {@link SwipeListener}
+         * @return the builder
+         */
+        public Builder setOnDismiss(SwipeListener onDismiss) {
+            this.onDismiss = onDismiss;
+            return this;
+        }
+
+        /**
+         * Assemble the {@link ViewModelBrick}
+         *
+         * @return the complete {@link ViewModelBrick}
+         */
+        public ViewModelBrick build() {
+            return new ViewModelBrick(this);
+        }
+
+        /**
+         * Get the default size
+         *
+         * @return the default {@link BrickSize}
+         */
+        protected BrickSize getDefaultSize() {
+            return DEFAULT_SIZE_FULL_WIDTH;
+        }
+
+        /**
+         * Get the default padding
+         *
+         * @return the default {@link BrickPadding}
+         */
+        protected BrickPadding getDefaultPadding() {
+            return DEFAULT_PADDING_NONE;
+        }
+    }
+
+    /**
+     * Gets the appropriate {@link ViewModel} for the given binding id.
+     *
+     * @param bindId the binding id
+     * @return a {@link ViewModel} for the binding id
+     */
+    public ViewModel getViewModel(int bindId) {
+        return viewModels.get(bindId);
+    }
+
+    /**
+     * Gets all {@link ViewModel}s.
+     *
+     * @return a {@link ViewModel} for the binding id
+     */
+    public SparseArray<ViewModel> getViewModels() {
+        return viewModels;
+    }
+
+    /**
+     * Add a view model to the Brick
+     *
+     * @param bindingId the binding ID of the view model
+     * @param viewModel the view model
+     */
+    public void addViewModel(int bindingId, ViewModel viewModel) {
+        this.viewModels.put(bindingId, viewModel);
+    }
+
+    /**
+     * Replace all the view models with these
+     *
+     * @param viewModels the view models to replace existing view models
+     */
+    public void setViewModels(SparseArray<ViewModel> viewModels) {
+        this.viewModels.clear();
+        for(int i = 0; i < viewModels.size(); i++) {
+            this.viewModels.put(viewModels.keyAt(i), viewModels.valueAt(i));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onBindData(BrickViewHolder holder) {
+        ViewModelBrickViewHolder viewModelBrickViewHolder = (ViewModelBrickViewHolder) holder;
+
+        for (int i = 0; i < viewModels.size(); i++) {
+            viewModelBrickViewHolder.bind(viewModels.keyAt(i), viewModels.valueAt(i));
+        }
+
+        viewModelBrickViewHolder.getViewDataBinding().executePendingBindings();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getLayout() {
+        return layoutId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrickViewHolder createViewHolder(View itemView) {
+        return new ViewModelBrickViewHolder(DataBindingUtil.bind(itemView));
+    }
+
+    /**
+     * Run the {@link SwipeListener} when a swipe happens on this brick.
+     *
+     * @param direction one of {@link android.support.v7.widget.helper.ItemTouchHelper.UP},
+     *                  {@link android.support.v7.widget.helper.ItemTouchHelper.RIGHT},
+     *                  {@link android.support.v7.widget.helper.ItemTouchHelper.DOWN},
+     *                  {@link android.support.v7.widget.helper.ItemTouchHelper.LEFT}
+     */
+    @SuppressWarnings("JavadocReference")
+    @Override
+    public void dismissed(int direction) {
+        if (onDismiss != null) {
+            onDismiss.swiped(direction);
+        }
+    }
+
+    /**
+     * Set the action for this brick being swiped.
+     *
+     * @param onDismiss the {@link SwipeListener} to be run on swipe
+     */
+    public void setOnDismiss(SwipeListener onDismiss) {
+        this.onDismiss = onDismiss;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onChange() {
+        setHidden(!isDataReady());
+
+        refreshItem();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isDataReady() {
+        boolean isDataReady = viewModels.size() != 0;
+
+        for (int i = 0; i < viewModels.size(); i++) {
+            isDataReady = viewModels.valueAt(i).isDataModelReady();
+
+            if (!isDataReady) {
+                break;
+            }
+        }
+
+        return isDataReady;
+    }
+
+    /**
+     * A special {@link BrickViewHolder} that can handle binding {@link ViewModel}s to layouts.
+     */
+    public static final class ViewModelBrickViewHolder extends BrickViewHolder {
+        public final ViewDataBinding viewDataBinding;
+
+        /**
+         * Constructor to set up the {@link BrickViewHolder} with the {@link ViewDataBinding}
+         * from the right item view.
+         *
+         * @param viewDataBinding the {@link ViewDataBinding} object
+         *                        from {@link #createViewHolder(View)}
+         */
+        public ViewModelBrickViewHolder(ViewDataBinding viewDataBinding) {
+            super(viewDataBinding.getRoot());
+
+            this.viewDataBinding = viewDataBinding;
+        }
+
+        /**
+         * Sets the {@link ViewModel} to be bound for the given id.
+         *
+         * @param bindId the id
+         * @param viewModel the {@link ViewModel}
+         */
+        void bind(int bindId, ViewModel viewModel) {
+            viewDataBinding.setVariable(bindId, viewModel);
+        }
+
+        /**
+         * gets the {@link ViewDataBinding} object in order to execute them
+         * {@link #onBindData(BrickViewHolder)}.
+         *
+         * @return the {@link ViewDataBinding}
+         */
+        ViewDataBinding getViewDataBinding() {
+            return viewDataBinding;
+        }
+    }
+}

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
@@ -14,56 +14,12 @@ import com.wayfair.brickkit.size.BrickSize;
  * This class is used as a Generic Brick that can take in any XML Layout and use DataBinding to
  * insert information from a {@link ViewModel}.
  */
-public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpdateListener {
+public final class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpdateListener {
     @LayoutRes
     private final int layoutId;
     protected final SparseArray<ViewModel> viewModels;
 
     protected SwipeListener onDismiss;
-
-//    /**
-//     * Constructor for setting up a ViewModelBrick with only one {@link ViewModel}.
-//     *
-//     * @param spanSize size information for this brick
-//     * @param padding padding for this brick
-//     * @param layoutId the id {@link LayoutRes} for the XML
-//     * @param bindId the id generated for the "variable" from {@link ViewDataBinding}
-//     * @param viewModel the {@link ViewModel} to bind the the XML
-//     */
-//    ViewModelBrick(BrickSize spanSize, BrickPadding padding,
-//                          @LayoutRes int layoutId, int bindId, ViewModel viewModel) {
-//        super(spanSize, padding);
-//
-//        this.layoutId = layoutId;
-//        this.viewModels = new SparseArray<>();
-//        this.viewModels.put(bindId, viewModel);
-//
-//        for (int i = 0; i < viewModels.size(); i++) {
-//            viewModels.valueAt(i).addUpdateListener(this);
-//        }
-//    }
-//
-//
-//    /**
-//     * Constructor for setting up a ViewModelBrick with only one {@link ViewModel}.
-//     *
-//     * @param spanSize size information for this brick
-//     * @param padding padding for this brick
-//     * @param layoutId the id {@link LayoutRes} for the XML
-//     * @param viewModels the {@link ViewModel}s and ids generated for the "variable"
-//     *                   from {@link ViewDataBinding} to bind the the XML
-//     */
-//    ViewModelBrick(BrickSize spanSize, BrickPadding padding,
-//                          @LayoutRes int layoutId, SparseArray<ViewModel> viewModels) {
-//        super(spanSize, padding);
-//
-//        this.layoutId = layoutId;
-//        this.viewModels = viewModels;
-//
-//        for (int i = 0; i < viewModels.size(); i++) {
-//            viewModels.valueAt(i).addUpdateListener(this);
-//        }
-//    }
 
     /**
      * Private constructor that the {@link Builder} class uses.

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
@@ -206,6 +206,33 @@ public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpda
         return isDataReady;
     }
 
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        boolean areContentsTheSame = true;
+
+        if (obj instanceof ViewModelBrick) {
+            for (int i = 0; i < getViewModels().size(); i++) {
+                for (int j = 0; j < ((ViewModelBrick) obj).getViewModels().size(); j++) {
+                    if (getViewModels().keyAt(i) == ((ViewModelBrick) obj).getViewModels().keyAt(j)) {
+                        if (!getViewModels().valueAt(i).equals(((ViewModelBrick) obj).getViewModels().valueAt(j))) {
+                            areContentsTheSame = false;
+                        }
+                    }
+                }
+
+            }
+        } else {
+            areContentsTheSame = false;
+        }
+
+        return areContentsTheSame;
+    }
+
     /**
      * A builder class for {@link ViewModelBrick}, this makes it clearer what is required and what you are actually doing when creating
      * {@link ViewModelBrick}s.

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
@@ -21,49 +21,49 @@ public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpda
 
     protected SwipeListener onDismiss;
 
-    /**
-     * Constructor for setting up a ViewModelBrick with only one {@link ViewModel}.
-     *
-     * @param spanSize size information for this brick
-     * @param padding padding for this brick
-     * @param layoutId the id {@link LayoutRes} for the XML
-     * @param bindId the id generated for the "variable" from {@link ViewDataBinding}
-     * @param viewModel the {@link ViewModel} to bind the the XML
-     */
-    ViewModelBrick(BrickSize spanSize, BrickPadding padding,
-                          @LayoutRes int layoutId, int bindId, ViewModel viewModel) {
-        super(spanSize, padding);
-
-        this.layoutId = layoutId;
-        this.viewModels = new SparseArray<>();
-        this.viewModels.put(bindId, viewModel);
-
-        for (int i = 0; i < viewModels.size(); i++) {
-            viewModels.valueAt(i).addUpdateListener(this);
-        }
-    }
-
-
-    /**
-     * Constructor for setting up a ViewModelBrick with only one {@link ViewModel}.
-     *
-     * @param spanSize size information for this brick
-     * @param padding padding for this brick
-     * @param layoutId the id {@link LayoutRes} for the XML
-     * @param viewModels the {@link ViewModel}s and ids generated for the "variable"
-     *                   from {@link ViewDataBinding} to bind the the XML
-     */
-    ViewModelBrick(BrickSize spanSize, BrickPadding padding,
-                          @LayoutRes int layoutId, SparseArray<ViewModel> viewModels) {
-        super(spanSize, padding);
-
-        this.layoutId = layoutId;
-        this.viewModels = viewModels;
-
-        for (int i = 0; i < viewModels.size(); i++) {
-            viewModels.valueAt(i).addUpdateListener(this);
-        }
-    }
+//    /**
+//     * Constructor for setting up a ViewModelBrick with only one {@link ViewModel}.
+//     *
+//     * @param spanSize size information for this brick
+//     * @param padding padding for this brick
+//     * @param layoutId the id {@link LayoutRes} for the XML
+//     * @param bindId the id generated for the "variable" from {@link ViewDataBinding}
+//     * @param viewModel the {@link ViewModel} to bind the the XML
+//     */
+//    ViewModelBrick(BrickSize spanSize, BrickPadding padding,
+//                          @LayoutRes int layoutId, int bindId, ViewModel viewModel) {
+//        super(spanSize, padding);
+//
+//        this.layoutId = layoutId;
+//        this.viewModels = new SparseArray<>();
+//        this.viewModels.put(bindId, viewModel);
+//
+//        for (int i = 0; i < viewModels.size(); i++) {
+//            viewModels.valueAt(i).addUpdateListener(this);
+//        }
+//    }
+//
+//
+//    /**
+//     * Constructor for setting up a ViewModelBrick with only one {@link ViewModel}.
+//     *
+//     * @param spanSize size information for this brick
+//     * @param padding padding for this brick
+//     * @param layoutId the id {@link LayoutRes} for the XML
+//     * @param viewModels the {@link ViewModel}s and ids generated for the "variable"
+//     *                   from {@link ViewDataBinding} to bind the the XML
+//     */
+//    ViewModelBrick(BrickSize spanSize, BrickPadding padding,
+//                          @LayoutRes int layoutId, SparseArray<ViewModel> viewModels) {
+//        super(spanSize, padding);
+//
+//        this.layoutId = layoutId;
+//        this.viewModels = viewModels;
+//
+//        for (int i = 0; i < viewModels.size(); i++) {
+//            viewModels.valueAt(i).addUpdateListener(this);
+//        }
+//    }
 
     /**
      * Private constructor that the {@link Builder} class uses.
@@ -195,12 +195,8 @@ public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpda
     public boolean isDataReady() {
         boolean isDataReady = viewModels.size() != 0;
 
-        for (int i = 0; i < viewModels.size(); i++) {
+        for (int i = 0; isDataReady && i < viewModels.size(); i++) {
             isDataReady = viewModels.valueAt(i).isDataModelReady();
-
-            if (!isDataReady) {
-                break;
-            }
         }
 
         return isDataReady;

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
@@ -3,7 +3,6 @@ package com.wayfair.brickkit.brick;
 import android.databinding.DataBindingUtil;
 import android.databinding.ViewDataBinding;
 import android.support.annotation.LayoutRes;
-import android.support.annotation.NonNull;
 import android.util.SparseArray;
 import android.view.View;
 
@@ -67,7 +66,7 @@ public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpda
     }
 
     /**
-     * Private constructor that the {@link Builder} class uses
+     * Private constructor that the {@link Builder} class uses.
      *
      * @param builder the builder
      */
@@ -80,113 +79,6 @@ public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpda
 
         for (int i = 0; i < viewModels.size(); i++) {
             viewModels.valueAt(i).addUpdateListener(this);
-        }
-    }
-
-    /**
-     * A builder class for {@link ViewModelBrick}, this makes it clearer what is required and what you are actually doing when creating
-     * {@link ViewModelBrick}s.
-     */
-    public static class Builder {
-        @LayoutRes
-        int layoutId;
-        SparseArray<ViewModel> viewModels = new SparseArray<>();
-        BrickSize spanSize = getDefaultSize();
-        BrickPadding padding = getDefaultPadding();
-        SwipeListener onDismiss = null;
-
-        /**
-         * Builder constructor, requires only a {@link LayoutRes} to work.
-         *
-         * @param layoutId a {@link LayoutRes} to use as a brick
-         */
-        public Builder(@LayoutRes int layoutId) {
-            this.layoutId = layoutId;
-        }
-
-        /**
-         * Add a {@link ViewModel} with a binding Id for the layout already defined.
-         *
-         * @param bindingId the binding Id of the view model
-         * @param viewModel the view model to be bound, extends {@link ViewModel}
-         * @return the builder
-         */
-        public Builder addViewModel(int bindingId, ViewModel viewModel) {
-            if (viewModel != null) {
-                this.viewModels.put(bindingId, viewModel);
-            }
-            return this;
-        }
-
-        /**
-         * Add a set of {@link ViewModel}s and their binding Ids.
-         *
-         * @param viewModels a {@link SparseArray} of binding Ids and {@link ViewModel}s
-         * @return the builder
-         */
-        public Builder setViewModels(SparseArray<ViewModel> viewModels) {
-            this.viewModels = viewModels;
-            return this;
-        }
-
-        /**
-         * Set the {@link BrickSize}
-         *
-         * @param spanSize the {@link BrickSize}
-         * @return the builder
-         */
-        public Builder setSpanSize(BrickSize spanSize) {
-            this.spanSize = spanSize;
-            return this;
-        }
-
-        /**
-         * Set the {@link BrickPadding}
-         *
-         * @param padding the {@link BrickPadding}
-         * @return the builder
-         */
-        public Builder setPadding(BrickPadding padding) {
-            this.padding = padding;
-            return this;
-        }
-
-        /**
-         * Set the {@link SwipeListener}
-         *
-         * @param onDismiss the {@link SwipeListener}
-         * @return the builder
-         */
-        public Builder setOnDismiss(SwipeListener onDismiss) {
-            this.onDismiss = onDismiss;
-            return this;
-        }
-
-        /**
-         * Assemble the {@link ViewModelBrick}
-         *
-         * @return the complete {@link ViewModelBrick}
-         */
-        public ViewModelBrick build() {
-            return new ViewModelBrick(this);
-        }
-
-        /**
-         * Get the default size
-         *
-         * @return the default {@link BrickSize}
-         */
-        protected BrickSize getDefaultSize() {
-            return DEFAULT_SIZE_FULL_WIDTH;
-        }
-
-        /**
-         * Get the default padding
-         *
-         * @return the default {@link BrickPadding}
-         */
-        protected BrickPadding getDefaultPadding() {
-            return DEFAULT_PADDING_NONE;
         }
     }
 
@@ -210,7 +102,7 @@ public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpda
     }
 
     /**
-     * Add a view model to the Brick
+     * Add a view model to the Brick.
      *
      * @param bindingId the binding ID of the view model
      * @param viewModel the view model
@@ -220,13 +112,13 @@ public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpda
     }
 
     /**
-     * Replace all the view models with these
+     * Replace all the view models with these.
      *
      * @param viewModels the view models to replace existing view models
      */
     public void setViewModels(SparseArray<ViewModel> viewModels) {
         this.viewModels.clear();
-        for(int i = 0; i < viewModels.size(); i++) {
+        for (int i = 0; i < viewModels.size(); i++) {
             this.viewModels.put(viewModels.keyAt(i), viewModels.valueAt(i));
         }
     }
@@ -312,6 +204,113 @@ public class ViewModelBrick extends BaseBrick implements ViewModel.ViewModelUpda
         }
 
         return isDataReady;
+    }
+
+    /**
+     * A builder class for {@link ViewModelBrick}, this makes it clearer what is required and what you are actually doing when creating
+     * {@link ViewModelBrick}s.
+     */
+    public static class Builder {
+        @LayoutRes
+        int layoutId;
+        SparseArray<ViewModel> viewModels = new SparseArray<>();
+        BrickSize spanSize = getDefaultSize();
+        BrickPadding padding = getDefaultPadding();
+        SwipeListener onDismiss = null;
+
+        /**
+         * Builder constructor, requires only a {@link LayoutRes} to work.
+         *
+         * @param layoutId a {@link LayoutRes} to use as a brick
+         */
+        public Builder(@LayoutRes int layoutId) {
+            this.layoutId = layoutId;
+        }
+
+        /**
+         * Add a {@link ViewModel} with a binding Id for the layout already defined.
+         *
+         * @param bindingId the binding Id of the view model
+         * @param viewModel the view model to be bound, extends {@link ViewModel}
+         * @return the builder
+         */
+        public Builder addViewModel(int bindingId, ViewModel viewModel) {
+            if (viewModel != null) {
+                this.viewModels.put(bindingId, viewModel);
+            }
+            return this;
+        }
+
+        /**
+         * Add a set of {@link ViewModel}s and their binding Ids.
+         *
+         * @param viewModels a {@link SparseArray} of binding Ids and {@link ViewModel}s
+         * @return the builder
+         */
+        public Builder setViewModels(SparseArray<ViewModel> viewModels) {
+            this.viewModels = viewModels;
+            return this;
+        }
+
+        /**
+         * Set the {@link BrickSize}.
+         *
+         * @param spanSize the {@link BrickSize}
+         * @return the builder
+         */
+        public Builder setSpanSize(BrickSize spanSize) {
+            this.spanSize = spanSize;
+            return this;
+        }
+
+        /**
+         * Set the {@link BrickPadding}.
+         *
+         * @param padding the {@link BrickPadding}
+         * @return the builder
+         */
+        public Builder setPadding(BrickPadding padding) {
+            this.padding = padding;
+            return this;
+        }
+
+        /**
+         * Set the {@link SwipeListener}.
+         *
+         * @param onDismiss the {@link SwipeListener}
+         * @return the builder
+         */
+        public Builder setOnDismiss(SwipeListener onDismiss) {
+            this.onDismiss = onDismiss;
+            return this;
+        }
+
+        /**
+         * Assemble the {@link ViewModelBrick}.
+         *
+         * @return the complete {@link ViewModelBrick}
+         */
+        public ViewModelBrick build() {
+            return new ViewModelBrick(this);
+        }
+
+        /**
+         * Get the default size.
+         *
+         * @return the default {@link BrickSize}
+         */
+        protected BrickSize getDefaultSize() {
+            return DEFAULT_SIZE_FULL_WIDTH;
+        }
+
+        /**
+         * Get the default padding.
+         *
+         * @return the default {@link BrickPadding}
+         */
+        protected BrickPadding getDefaultPadding() {
+            return DEFAULT_PADDING_NONE;
+        }
     }
 
     /**

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/models/TextDataModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/models/TextDataModel.java
@@ -1,0 +1,47 @@
+package com.wayfair.brickkit.models;
+
+import com.wayfair.brickkit.brick.DataModel;
+
+/**
+ * Data model for text bricks.
+ */
+public class TextDataModel extends DataModel {
+    private String text;
+
+    /**
+     * Constructor.
+     *
+     * @param text the text
+     */
+    public TextDataModel(String text) {
+        this.text = text;
+    }
+
+    /**
+     * Return the text.
+     *
+     * @return the text
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Set a new value for text.
+     *
+     * @param text the new text
+     */
+    public void setText(String text) {
+        this.text = text;
+        notifyChange();
+    }
+
+    /**
+     * Append the string to the existing text.
+     *
+     * @param newText the new sting to be appended
+     */
+    public void appendText(String newText) {
+        setText(text + newText);
+    }
+}

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/models/TextViewModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/models/TextViewModel.java
@@ -1,0 +1,30 @@
+package com.wayfair.brickkit.models;
+
+import android.databinding.Bindable;
+
+import com.wayfair.brickkit.brick.ViewModel;
+
+/**
+ * A view model for a text brick.
+ */
+public class TextViewModel extends ViewModel<TextDataModel> {
+
+    /**
+     * Constructor.
+     *
+     * @param dataModel the {@link TextDataModel}
+     */
+    public TextViewModel(TextDataModel dataModel) {
+        super(dataModel);
+    }
+
+    /**
+     * Method that data binding uses to set the view's text.
+     *
+     * @return the text
+     */
+    @Bindable
+    public String getText() {
+        return getDataModel().getText();
+    }
+}

--- a/BrickKit/bricks/src/main/res/layout/text_brick_vm.xml
+++ b/BrickKit/bricks/src/main/res/layout/text_brick_vm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright © 2017 Wayfair. All rights reserved. -->
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <data>
+        <variable
+            name="textViewModel"
+            type="com.wayfair.brickkit.models.TextViewModel"/>
+    </data>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" >
+
+        <TextView
+            android:id="@+id/text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@android:color/black"
+            android:textSize="31sp"
+            android:background="@android:color/white"
+            android:padding="@dimen/default_brick_content_padding"
+            android:text="@{textViewModel.text}"
+            tools:text="Some text. Some text. Some text. Some text. Some text. Some text. Some text. Some text. " />
+
+    </RelativeLayout>
+
+</layout>

--- a/BrickKit/build.gradle
+++ b/BrickKit/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/BrickKit/config/quality/checkstyle/checkstyle.xml
+++ b/BrickKit/config/quality/checkstyle/checkstyle.xml
@@ -54,9 +54,6 @@
         <module name="InnerAssignment" />
         <!--<module name="MagicNumber" />-->
         <module name="MissingSwitchDefault" />
-        <module name="RedundantThrows">
-            <property name="suppressLoadErrors" value="true" />
-        </module>
         <module name="SimplifyBooleanExpression" />
         <module name="SimplifyBooleanReturn" />
         <module name="DesignForExtension">

--- a/BrickKit/gradle/wrapper/gradle-wrapper.properties
+++ b/BrickKit/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Wed Nov 01 19:10:12 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
- This allows you to use Android DataBinding to remove the need to create new Brick Classes and simply use one (`ViewModelBrick`).
- Allows you to tag Bricks and use those tags later to fetch from the DataManager.
- Adds a cache for Bricks by LayoutID, allowing you to "remove based on brick type" while using `ViewModelBrick`.
- Adds examples of using `ViewModelBrick` into `SimpleBrickFragment` and `AddRemoveBrickFragment`
- Add more flexibility to the ViewModelBrick
- Rename for clarification of UpdateListeners
- Fixing interaction with placeholders
- Overriding isDataReady to actually test the viewModels
- Fixing Threading Issues
- Hiding Constructors
- Moving App over to Builder Pattern
- Adding JavaDocs