### PR TITLE
Fix Serializable Issues

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/DataModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/DataModel.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * when {@link #notifyChange()} is called.
  */
 public abstract class DataModel implements Serializable {
-    protected final Set<DataModelUpdateListener> updateListeners = new ArraySet<>();
+    protected transient final Set<DataModelUpdateListener> updateListeners = new ArraySet<>();
 
     /**
      * Add an {@link DataModelUpdateListener} to the list of listeners.

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/DataModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/DataModel.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * when {@link #notifyChange()} is called.
  */
 public abstract class DataModel implements Serializable {
-    protected transient final Set<DataModelUpdateListener> updateListeners = new ArraySet<>();
+    protected final transient Set<DataModelUpdateListener> updateListeners = new ArraySet<>();
 
     /**
      * Add an {@link DataModelUpdateListener} to the list of listeners.

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
@@ -13,7 +13,7 @@ import java.util.Set;
  */
 public abstract class ViewModel<DM extends DataModel> extends BaseObservable implements DataModel.DataModelUpdateListener {
     protected DM dataModel;
-    protected transient final Set<ViewModelUpdateListener> updateListeners = new HashSet<>();
+    protected final transient Set<ViewModelUpdateListener> updateListeners = new HashSet<>();
 
     /**
      * Constructor. Automatically gets tied to the {@link DataModel} as

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
@@ -13,7 +13,7 @@ import java.util.Set;
  */
 public abstract class ViewModel<DM extends DataModel> extends BaseObservable implements DataModel.DataModelUpdateListener {
     protected DM dataModel;
-    protected final Set<ViewModelUpdateListener> updateListeners = new HashSet<>();
+    protected transient final Set<ViewModelUpdateListener> updateListeners = new HashSet<>();
 
     /**
      * Constructor. Automatically gets tied to the {@link DataModel} as


### PR DESCRIPTION
-  Adding `transient` means that `DataModel` and `ViewModel` don't need to adhere to `Serializable`