### PR TITLE
Call super.notifyChange() in our abstract ViewModel class

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModel.java
@@ -51,6 +51,7 @@ public abstract class ViewModel<DM extends DataModel> extends BaseObservable imp
 
     @Override
     public void notifyChange() {
+        super.notifyChange();
         for (ViewModelUpdateListener updateListener : getUpdateListeners()) {
             updateListener.onChange();
         }


### PR DESCRIPTION
May be the case of not having a DataModel attached to a ViewModel, but still we'd like to trigger BaseObservable properties for that very ViewModel in order to make the changes visible to the view.
Tested on the **android-ui-components** project which is making use of the ViewModel and DataModel that have been moved away from the main Wayfair project to BrickKit. 