### PR TITLE
Proposal for streamlined placeholder api

### DIFF
--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/MainActivityFragment.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/MainActivityFragment.java
@@ -4,15 +4,15 @@
 package com.wayfair.brickkitdemo;
 
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
+import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.wayfair.brickkit.brick.BaseBrick;
 import com.wayfair.brickkit.BrickFragment;
-import com.wayfair.brickkit.padding.InnerOuterBrickPadding;
+import com.wayfair.brickkit.brick.BaseBrick;
+import com.wayfair.brickkit.padding.BrickPadding;
+import com.wayfair.brickkit.padding.SimpleBrickPadding;
 import com.wayfair.brickkit.size.SimpleBrickSize;
 import com.wayfair.brickkitdemo.bricks.UnusedBrick;
 import com.wayfair.brickkitdemo.bricks.UsedBrick;
@@ -23,253 +23,116 @@ import java.util.ArrayList;
  * A placeholder fragment containing a simple view.
  */
 public class MainActivityFragment extends BrickFragment {
-    private static final int ONE_FIFTH = 48;
-    private static final int TWO_FIFTH = 96;
+    private static final int ONE_FIFTH = BaseBrick.DEFAULT_MAX_SPAN_COUNT / 5;
+    private static final int TWO_FIFTH = ONE_FIFTH * 2;
+
+    SimpleBrickPadding standardPadding = new SimpleBrickPadding(4);
+    SimpleBrickSize spanSizeTwoFifths = new SimpleBrickSize(maxSpans()) {
+        @Override
+        protected int size() {
+            return TWO_FIFTH;
+        }
+    };
+
+    // Padding brick to start the line
+    private SimpleBrickSize spanSizeOneFifth = new SimpleBrickSize(maxSpans()) {
+        @Override
+        protected int size() {
+            return ONE_FIFTH;
+        }
+    };
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        InnerOuterBrickPadding padding = new InnerOuterBrickPadding(8, 0);
-
         ArrayList<BaseBrick> usedBricks = new ArrayList<>();
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Simple Brick View",
+                new SimpleBrickFragment()));
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Header Brick View",
+                new HeaderBrickFragment()));
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Placeholder Brick View",
+                new PlaceholderBrickFragment()));
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Footer Brick View",
+                new FooterBrickFragment()));
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Expandable Brick View",
+                new ExpandableHeaderFooterFragment()));
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Add/Remove Brick View",
+                new AddRemoveBrickFragment()));
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Infinite Scroll Brick View",
+                new InfiniteScrollBrickFragment()));
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Staggered Infinite Scroll Brick View",
+                new StaggeredInfiniteScrollBrickFragment()));
+        usedBricks.add(getNavigationBrick(standardPadding,
+                "Fragment Brick View",
+                new FragmentBrickFragment()));
+        addBricksToDataManager(usedBricks);
+    }
 
-        final UsedBrick usedBrick = new UsedBrick(
-                new SimpleBrickSize(maxSpans()) {
-                    @Override
-                    protected int size() {
-                        return TWO_FIFTH;
-                    }
-                },
+    /**
+     * Adds bricks to the datamanager. Includes some generated bricks for a masonry pattern.
+     * @param usedBricks The bricks which have real content, and are to be added to the screen.
+     */
+    private void addBricksToDataManager(ArrayList<BaseBrick> usedBricks) {
+        final UnusedBrick oneFifthBrick = new UnusedBrick(spanSizeOneFifth, standardPadding);
+        final UnusedBrick twoFifthsBrick = new UnusedBrick(spanSizeTwoFifths, standardPadding);
+
+        for (int i = 0; i < usedBricks.size() + 2; i++) {
+
+            final BaseBrick first;
+            final BaseBrick last;
+
+            if (i % 2 == 0) {
+                first = oneFifthBrick;
+                last = twoFifthsBrick;
+            } else {
+                first = twoFifthsBrick;
+                last = oneFifthBrick;
+            }
+
+            dataManager.addLast(first);
+            if (i == 0 || i == usedBricks.size() + 1) {
+                dataManager.addLast(new UnusedBrick(spanSizeTwoFifths, standardPadding));
+            } else {
+                dataManager.addLast(usedBricks.get(i - 1));
+            }
+            dataManager.addLast(last);
+        }
+    }
+
+    /**
+     * Used to return the navigation brick which is used in multiple places on this page.
+     *
+     * @param padding  The standardPadding which will be applied to the brick
+     * @param text     The text which will show up on the generated text brick
+     * @param fragment The fragment which the brick will navigate to, after it is clicked.
+     * @return Returns a brick with text which will navigate to a given fragment when clicked.
+     */
+    @NonNull
+    private UsedBrick getNavigationBrick(BrickPadding padding,
+                                         String text,
+                                         final BrickFragment fragment) {
+        return new UsedBrick(
+                spanSizeTwoFifths,
                 padding,
+                text,
                 new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
                         getFragmentManager().beginTransaction()
-                                .replace(R.id.content, new SimpleBrickFragment())
+                                .replace(R.id.content, fragment)
                                 .addToBackStack(null)
                                 .commit();
                     }
                 }
         );
-        usedBricks.add(usedBrick);
-
-        // Fake waiting as in a API request to show off placeholder when data is not ready
-        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                usedBrick.setText("Simple Brick View");
-                dataManager.refreshItem(usedBrick);
-            }
-        }, 2000);
-
-        usedBricks.add(
-                new UsedBrick(
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        },
-                        padding,
-                        "Header Brick View",
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                getFragmentManager().beginTransaction()
-                                        .replace(R.id.content, new HeaderBrickFragment())
-                                        .addToBackStack(null)
-                                        .commit();
-                            }
-                        }
-                )
-        );
-        usedBricks.add(
-                new UsedBrick(
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        },
-                        padding,
-                        "Footer Brick View",
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                getFragmentManager().beginTransaction()
-                                        .replace(R.id.content, new FooterBrickFragment())
-                                        .addToBackStack(null)
-                                        .commit();
-                            }
-                        }
-                )
-        );
-        usedBricks.add(
-                new UsedBrick(
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        },
-                        padding,
-                        "Expandable Brick View",
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                getFragmentManager().beginTransaction()
-                                        .replace(R.id.content, new ExpandableHeaderFooterFragment())
-                                        .addToBackStack(null)
-                                        .commit();
-                            }
-                        }
-                )
-        );
-        usedBricks.add(
-                new UsedBrick(
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        },
-                        padding,
-                        "Add/Remove Brick View",
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                getFragmentManager().beginTransaction()
-                                        .replace(R.id.content, new AddRemoveBrickFragment())
-                                        .addToBackStack(null)
-                                        .commit();
-                            }
-                        }
-                )
-        );
-        usedBricks.add(
-                new UsedBrick(
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        },
-                        padding,
-                        "Infinite Scroll Brick View",
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                getFragmentManager().beginTransaction()
-                                        .replace(R.id.content, new InfiniteScrollBrickFragment())
-                                        .addToBackStack(null)
-                                        .commit();
-                            }
-                        }
-                )
-        );
-        usedBricks.add(
-                new UsedBrick(
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        },
-                        padding,
-                        "Staggered Infinite Scroll Brick View",
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                getFragmentManager().beginTransaction()
-                                        .replace(R.id.content, new StaggeredInfiniteScrollBrickFragment())
-                                        .addToBackStack(null)
-                                        .commit();
-                            }
-                        }
-                )
-        );
-        usedBricks.add(
-                new UsedBrick(
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        },
-                        padding,
-                        "Fragment Brick View",
-                        new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                getFragmentManager().beginTransaction()
-                                        .replace(R.id.content, new FragmentBrickFragment())
-                                        .addToBackStack(null)
-                                        .commit();
-                            }
-                        }
-                )
-        );
-
-        for (int i = 0; i < usedBricks.size() + 2; i++) {
-            SimpleBrickSize first;
-            SimpleBrickSize last;
-
-            if (i % 2 == 0) {
-                first =
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return ONE_FIFTH;
-                            }
-                        };
-                last =
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        };
-            } else {
-                first =
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        };
-                last =
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return ONE_FIFTH;
-                            }
-                        };
-            }
-
-            UnusedBrick unusedBrick1 = new UnusedBrick(first, padding);
-            dataManager.addLast(unusedBrick1);
-
-            if (i == 0 || i == usedBricks.size() + 1) {
-                UnusedBrick unusedBrick = new UnusedBrick(
-                        new SimpleBrickSize(maxSpans()) {
-                            @Override
-                            protected int size() {
-                                return TWO_FIFTH;
-                            }
-                        },
-                        padding
-                );
-                dataManager.addLast(unusedBrick);
-            } else {
-                dataManager.addLast(usedBricks.get(i - 1));
-            }
-
-            UnusedBrick unusedBrick2 = new UnusedBrick(last, padding);
-            dataManager.addLast(unusedBrick2);
-
-        }
-
     }
 
     @Override

--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/PlaceholderBrickFragment.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/PlaceholderBrickFragment.java
@@ -1,0 +1,235 @@
+package com.wayfair.brickkitdemo;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.AnimatorSet;
+import android.animation.ObjectAnimator;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.SparseArray;
+import android.view.View;
+
+import com.wayfair.brickkit.BrickFragment;
+import com.wayfair.brickkit.BrickViewHolder;
+import com.wayfair.brickkit.brick.BaseBrick;
+import com.wayfair.brickkit.brick.LayoutBinder;
+import com.wayfair.brickkit.brick.ViewModel;
+import com.wayfair.brickkit.brick.ViewModelBrick;
+import com.wayfair.brickkit.models.TextDataModel;
+import com.wayfair.brickkit.models.TextViewModel;
+import com.wayfair.brickkit.padding.SimpleBrickPadding;
+import com.wayfair.brickkit.size.SimpleBrickSize;
+import com.wayfair.brickkitdemo.bricks.UnusedBrick;
+
+import java.util.ArrayList;
+
+/**
+ * A fragment which shows off the {@link ViewModelBrick}'s ability to bind multiple times.
+ * This allows for us to create placeholder bricks, and bind to them when the data is received.
+ */
+public class PlaceholderBrickFragment extends BrickFragment {
+    private static final int ONE_FIFTH = BaseBrick.DEFAULT_MAX_SPAN_COUNT / 5;
+    private static final int TWO_FIFTH = ONE_FIFTH * 2;
+    private static final String PLACEHOLDER = "placeholder";
+    private static final String PLACEHOLDER_MULTIBIND = "placeholder_multibind";
+    SimpleBrickPadding standardPadding = new SimpleBrickPadding(4);
+    UnusedBrick brickTwoFifths = getSizedBrick(TWO_FIFTH);
+    UnusedBrick brickOneFifth = getSizedBrick(ONE_FIFTH);
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ArrayList<BaseBrick> bricks = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            if (i % 2 == 0) {
+                bricks.add(brickOneFifth);
+            } else {
+                bricks.add(brickTwoFifths);
+            }
+            bricks.add(getPlaceholder(PLACEHOLDER));
+            if (i % 2 == 0) {
+                bricks.add(brickTwoFifths);
+            } else {
+                bricks.add(brickOneFifth);
+            }
+        }
+
+        bricks.add(brickOneFifth);
+        bricks.add(getPlaceholder(PLACEHOLDER_MULTIBIND));
+        bricks.add(brickTwoFifths);
+
+        dataManager.addLast(bricks);
+
+        setPlaceholderDelayedAction(PLACEHOLDER, new BindingAction() {
+            @Override
+            public void perform(ViewModelBrick brick) {
+                brick.replaceLayoutWith(
+                        R.layout.text_brick_vm,
+                        new SparseArray<ViewModel>() {{
+                            append(
+                                    BR.textViewModel,
+                                    new TextViewModel(
+                                            new TextDataModel("AFTER")
+                                    )
+                            );
+                        }});
+            }
+        });
+
+        startMultiBindingBrickSequence();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        dataManager.clear();
+    }
+
+    /**
+     * Generating a placeholder brick. We can add a tag for the brick, so that we can grab it later.
+     *
+     * @param tag The tag that we want to associate with the placeholder brick.
+     * @return A new placeholder ViewModelBrick.
+     */
+    private BaseBrick getPlaceholder(String tag) {
+        BaseBrick brick = new ViewModelBrick.Builder(R.layout.text_brick_vm_placeholder)
+                .setPadding(standardPadding)
+                .setSpanSize(
+                        new SimpleBrickSize(maxSpans()) {
+                            @Override
+                            protected int size() {
+                                return TWO_FIFTH;
+                            }
+                        }
+                )
+                .setCustomBinding(new LayoutBinder() {
+                    @Override
+                    public void onBindLayout(BrickViewHolder holder) {
+                        setAlphaAnimation(holder.itemView);
+                    }
+                })
+                .build();
+        brick.setTag(tag);
+        return brick;
+    }
+
+    /**
+     * Takes a tag and an action, and calls the action on each of the bricks in the datamanager who
+     * match the tag, after a 2 second delay. This is meant to simulate a long-running activity,
+     * such as a network request.
+     *
+     * @param placeholder The tag that we want to associate with the brick
+     * @param action The action that we want to perform on bricks that are matched.
+     */
+    private void setPlaceholderDelayedAction(final String placeholder, final BindingAction action) {
+        // Fake waiting as in a API request to show off placeholder when data is not ready
+        new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                for (BaseBrick brick : dataManager.getBricksByTag(placeholder)) {
+                    ViewModelBrick viewModelBrick = (ViewModelBrick) brick;
+                    action.perform(viewModelBrick);
+                }
+            }
+        }, 2000);
+    }
+
+    /**
+     * A convenience method which returns a brick which is fits the desired width.
+     * @param spanSize The spansize that we would like the brick to be.
+     *                 Check out {@link com.wayfair.brickkit.size.BrickSize} for more information.
+     * @return An UnusedBrick which is sized correctly.
+     */
+    @NonNull
+    private UnusedBrick getSizedBrick(final int spanSize) {
+        return new UnusedBrick(
+                new SimpleBrickSize(maxSpans()) {
+                    @Override
+                    protected int size() {
+                        return spanSize;
+                    }
+                },
+                standardPadding);
+    }
+
+    /**
+     * Sets a fade in / fade out animation on a view.
+     * @param v The view which is going to be animated.
+     */
+    public void setAlphaAnimation(View v) {
+        ObjectAnimator fadeOut = ObjectAnimator.ofFloat(v, "alpha", 1f, .3f);
+        fadeOut.setDuration(500);
+        ObjectAnimator fadeIn = ObjectAnimator.ofFloat(v, "alpha", .3f, 1f);
+        fadeIn.setDuration(500);
+
+        final AnimatorSet mAnimationSet = new AnimatorSet();
+
+        mAnimationSet.play(fadeIn).after(fadeOut);
+
+        mAnimationSet.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                super.onAnimationEnd(animation);
+                mAnimationSet.start();
+            }
+        });
+        mAnimationSet.start();
+    }
+
+    /**
+     * NOTE: This is to demonstrate binding multiple times, please don't code like this.
+     * This method demonstrates binding to the same brick multiple times.
+     */
+    private void startMultiBindingBrickSequence() {
+        final BindingAction replaceStage3 = new BindingAction() {
+            @Override
+            public void perform(ViewModelBrick brick) {
+                brick.replaceLayoutWith(
+                        R.layout.text_brick_vm,
+                        new SparseArray<ViewModel>() {{
+                            append(BR.textViewModel, new TextViewModel(
+                                    new TextDataModel("Fourth Binding")));
+                        }});
+            }
+        };
+        final BindingAction replaceStage2 = new BindingAction() {
+            @Override
+            public void perform(ViewModelBrick brick) {
+                brick.replaceLayoutWith(
+                        R.layout.text_brick_vm_placeholder,
+                        new SparseArray<ViewModel>() {{
+                            append(BR.textViewModel, new TextViewModel(new TextDataModel("\n")));
+                        }});
+                setPlaceholderDelayedAction(PLACEHOLDER_MULTIBIND, replaceStage3);
+            }
+        };
+        final BindingAction replaceStage1 = new BindingAction() {
+            @Override
+            public void perform(ViewModelBrick brick) {
+                brick.replaceLayoutWith(
+                        R.layout.text_brick_vm,
+                        new SparseArray<ViewModel>() {{
+                            append(BR.textViewModel, new TextViewModel(
+                                    new TextDataModel("Second Binding")
+                            ));
+                        }});
+                setPlaceholderDelayedAction(PLACEHOLDER_MULTIBIND, replaceStage2);
+            }
+        };
+        setPlaceholderDelayedAction(PLACEHOLDER_MULTIBIND, replaceStage1);
+    }
+
+    /**
+     * An action that will take place when we are binding a brick for the second time.
+     */
+    interface BindingAction {
+        /**
+         * The action that will be performed on a brick when it is bound.
+         * @param brick The brick that the action will be performed on.
+         */
+        void perform(ViewModelBrick brick);
+    }
+}

--- a/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/bricks/UsedBrick.java
+++ b/BrickKit/app/src/main/java/com/wayfair/brickkitdemo/bricks/UsedBrick.java
@@ -59,6 +59,11 @@ public class UsedBrick extends BaseBrick implements TouchableBrick {
 
     @Override
     public void onBindData(final BrickViewHolder viewHolder) {
+
+    }
+
+    @Override
+    public void onBindSubsequentLayout(final BrickViewHolder viewHolder) {
         UsedBrickHolder holder = (UsedBrickHolder) viewHolder;
         holder.textView.setText(text);
         if (isEnabled()) {
@@ -67,18 +72,13 @@ public class UsedBrick extends BaseBrick implements TouchableBrick {
     }
 
     @Override
-    public void onBindPlaceholder(BrickViewHolder holder) {
-        // Here we would modify placeholder views dimensions if necessary
-    }
-
-    @Override
     public int getLayout() {
-        return R.layout.used_brick;
+        return R.layout.used_brick_placeholder;
     }
 
     @Override
-    public int getPlaceholderLayout() {
-        return R.layout.used_brick_placeholder;
+    public int getSubsequentLayout() {
+        return R.layout.used_brick;
     }
 
     @Override

--- a/BrickKit/app/src/main/res/layout/used_brick_placeholder.xml
+++ b/BrickKit/app/src/main/res/layout/used_brick_placeholder.xml
@@ -4,12 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@android:color/holo_blue_light"
-    android:paddingTop="24dp"
     android:paddingBottom="24dp"
-    android:paddingStart="@dimen/default_brick_content_padding"
     android:paddingEnd="@dimen/default_brick_content_padding"
-    app:intensity="0.2"
-    app:auto_start="true">
+    android:paddingStart="@dimen/default_brick_content_padding"
+    android:paddingTop="24dp"
+    app:auto_start="true"
+    app:intensity="0.2">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickRecyclerAdapterTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickRecyclerAdapterTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -399,7 +398,7 @@ public class BrickRecyclerAdapterTest {
 
         adapter.onBindViewHolder(holder, 0);
 
-        verify(brick).onBindPlaceholder(holder);
+        verify(brick).onBindSubsequentLayout(holder);
     }
 
     @Test
@@ -416,7 +415,7 @@ public class BrickRecyclerAdapterTest {
 
         adapter.onBindViewHolder(holder, 0);
 
-        verify(brick).onBindPlaceholder(holder);
+        verify(brick).onBindSubsequentLayout(holder);
         verify(listener).bindingItemAtPosition(0);
     }
 
@@ -479,7 +478,7 @@ public class BrickRecyclerAdapterTest {
     @Test
     public void testGetItemViewTypeWhenDataIsNotReady() {
         BaseBrick brick = mock(BaseBrick.class);
-        when(brick.getPlaceholderLayout()).thenReturn(PLACEHOLDER_LAYOUT);
+        when(brick.getSubsequentLayout()).thenReturn(PLACEHOLDER_LAYOUT);
         when(brick.isDataReady()).thenReturn(false);
 
         when(dataManager.brickAtPosition(0)).thenReturn(brick);

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/BaseBrickTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/BaseBrickTest.java
@@ -230,7 +230,7 @@ public class BaseBrickTest {
         }
 
         @Override
-        public int getPlaceholderLayout() {
+        public int getSubsequentLayout() {
             return 0;
         }
 

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/util/BrickTestHelper.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/util/BrickTestHelper.java
@@ -95,7 +95,7 @@ public class BrickTestHelper {
         }
 
         @Override
-        public int getPlaceholderLayout() {
+        public int getSubsequentLayout() {
             return placeholderLayoutId;
         }
 

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -29,7 +29,7 @@ import java.util.ListIterator;
  * Class which maintains a collection of bricks and manages how they are laid out in an provided RecyclerView.
  * <p>
  * This class maintains the bricks and handles notifying the underlying adapter when items are updated.
- *
+ * <p>
  * Copyright © 2017 Wayfair. All rights reserved.
  */
 public class BrickDataManager implements Serializable {
@@ -1135,14 +1135,13 @@ public class BrickDataManager implements Serializable {
     /**
      * Retrieves a brick who's associated placeholder layout resource ID matches that of the parameter.
      *
-     * @param placeholderLayoutResId Placeholder Layout resource ID
+     * @param layoutId Placeholder Layout resource ID
      * @return An instance of BaseBrick or null
      */
-    public BaseBrick brickWithPlaceholderLayout(@LayoutRes int placeholderLayoutResId) {
+    public BaseBrick brickWithPlaceholderLayout(@LayoutRes int layoutId) {
         List<BaseBrick> visibleItems = getRecyclerViewItems();
         for (int i = 0; i < visibleItems.size(); i++) {
-            if (!visibleItems.get(i).isDataReady() && visibleItems.get(i).getPlaceholderLayout()
-                    == placeholderLayoutResId) {
+            if (visibleItems.get(i).getSubsequentLayout() == layoutId) {
                 return visibleItems.get(i);
             }
         }
@@ -1171,7 +1170,7 @@ public class BrickDataManager implements Serializable {
         /**
          * Constructor for the NpaStaggeredGridLayoutManager.
          *
-         * @param spanCount the number of columns to use in the StaggeredGridLayoutManager.
+         * @param spanCount   the number of columns to use in the StaggeredGridLayoutManager.
          * @param orientation the orientation of the StaggeredGridLayoutManager.
          */
         NpaStaggeredGridLayoutManager(int spanCount, int orientation) {
@@ -1207,10 +1206,10 @@ public class BrickDataManager implements Serializable {
         /**
          * Constructor for the WFGridLayoutManager.
          *
-         * @param context            {@link Context} to use
-         * @param spanCount          the number of columns to which the bricks will conform
-         * @param orientation        Layout orientation. Should be {@link GridLayoutManager#HORIZONTAL} or {@link GridLayoutManager#VERTICAL}.
-         * @param reverseLayout      When set to true, layouts from end to start.
+         * @param context       {@link Context} to use
+         * @param spanCount     the number of columns to which the bricks will conform
+         * @param orientation   Layout orientation. Should be {@link GridLayoutManager#HORIZONTAL} or {@link GridLayoutManager#VERTICAL}.
+         * @param reverseLayout When set to true, layouts from end to start.
          */
         WFGridLayoutManager(Context context, int spanCount, int orientation, boolean reverseLayout) {
             super(context, spanCount, orientation, reverseLayout);

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -31,7 +31,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
      * Constructor.
      *
      * @param brickDataManager {@link BrickDataManager} for this adapter
-     * @param recyclerView {@link RecyclerView} for this adapter
+     * @param recyclerView     {@link RecyclerView} for this adapter
      */
     public BrickRecyclerAdapter(BrickDataManager brickDataManager, RecyclerView recyclerView) {
         if (recyclerView == null) {
@@ -66,7 +66,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
      * Safe version of {@link RecyclerView.Adapter#notifyItemChanged(int, Object)}.
      *
      * @param position Position of the item that has changed
-     * @param payload Optional parameter, use null to identify a "full" update
+     * @param payload  Optional parameter, use null to identify a "full" update
      */
     public void safeNotifyItemChanged(final int position, final Object payload) {
         if (recyclerView.isComputingLayout()) {
@@ -77,7 +77,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
     }
 
     /**
-     *  Safe version of {@link RecyclerView.Adapter#notifyItemChanged(int)}.
+     * Safe version of {@link RecyclerView.Adapter#notifyItemChanged(int)}.
      *
      * @param position Position of the item that has changed
      */
@@ -93,7 +93,6 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
      * Safe version of {@link RecyclerView.Adapter#notifyItemInserted(int)}.
      *
      * @param position Position of the newly inserted item in the data set
-
      */
     public void safeNotifyItemInserted(final int position) {
         if (recyclerView.isComputingLayout()) {
@@ -107,7 +106,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
      * Safe version of {@link RecyclerView.Adapter#notifyItemMoved(int, int)}.
      *
      * @param fromPosition Previous position of the item.
-     * @param toPosition New position of the item.
+     * @param toPosition   New position of the item.
      */
     public void safeNotifyItemMoved(final int fromPosition, final int toPosition) {
         if (recyclerView.isComputingLayout()) {
@@ -121,8 +120,8 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
      * Safe version of {@link RecyclerView.Adapter#notifyItemRangeChanged(int, int, Object)}.
      *
      * @param positionStart Position of the first item that has changed
-     * @param itemCount Number of items that have changed
-     * @param payload  Optional parameter, use null to identify a "full" update
+     * @param itemCount     Number of items that have changed
+     * @param payload       Optional parameter, use null to identify a "full" update
      */
     public void safeNotifyItemRangeChanged(final int positionStart, final int itemCount, final Object payload) {
         if (recyclerView.isComputingLayout()) {
@@ -136,7 +135,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
      * Safe version of {@link RecyclerView.Adapter#notifyItemRangeChanged(int, int)}.
      *
      * @param positionStart Position of the first item that has changed
-     * @param itemCount Number of items that have changed
+     * @param itemCount     Number of items that have changed
      */
     public void safeNotifyItemRangeChanged(final int positionStart, final int itemCount) {
         if (recyclerView.isComputingLayout()) {
@@ -150,7 +149,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
      * Safe version of {@link RecyclerView.Adapter#notifyItemRangeInserted(int, int)}.
      *
      * @param positionStart Position of the first item that was inserted
-     * @param itemCount Number of items inserted
+     * @param itemCount     Number of items inserted
      */
     public void safeNotifyItemRangeInserted(final int positionStart, final int itemCount) {
         if (recyclerView.isComputingLayout()) {
@@ -164,7 +163,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
      * Safe version of {@link RecyclerView.Adapter#notifyItemRangeRemoved(int, int)}.
      *
      * @param positionStart Previous position of the first item that was removed
-     * @param itemCount Number of items removed from the data set
+     * @param itemCount     Number of items removed from the data set
      */
     public void safeNotifyItemRangeRemoved(final int positionStart, final int itemCount) {
         if (recyclerView.isComputingLayout()) {
@@ -206,15 +205,27 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
                 }
             }
 
-            if (baseBrick.isDataReady()) {
-                baseBrick.onBindData(holder);
+            if (shouldUseSubsequentLayout(baseBrick)) {
+                baseBrick.onBindSubsequentLayout(holder);
             } else {
-                baseBrick.onBindPlaceholder(holder);
+                baseBrick.onBindData(holder);
             }
+
             if (onReachedItemAtPosition != null) {
                 onReachedItemAtPosition.bindingItemAtPosition(position);
             }
         }
+    }
+
+    /**
+     * Determines if we should bind on the original layout or the subsequent layout.
+     *
+     * @param baseBrick The brick which we are attempting to bind
+     * @return True if we should be binding the subsequent layout, and false otherwise.
+     */
+    private boolean shouldUseSubsequentLayout(BaseBrick baseBrick) {
+        return baseBrick.isDataReady()
+                && baseBrick.getSubsequentLayout() != BaseBrick.INVALID_LAYOUT;
     }
 
     @Override
@@ -240,8 +251,8 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
             return 0;
         }
 
-        if (!brick.isDataReady()) {
-            return brick.getPlaceholderLayout();
+        if (shouldUseSubsequentLayout(brick)) {
+            return brick.getSubsequentLayout();
         }
 
         return brick.getLayout();
@@ -259,6 +270,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
 
     /**
      * Get the index of the given brick.
+     *
      * @param brick brick to get the index of
      * @return index of the given brick
      */
@@ -268,6 +280,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
 
     /**
      * Get the first header before the given position.
+     *
      * @param position position before which to find the next header
      * @return the first header before the given position.
      */
@@ -293,6 +306,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
 
     /**
      * Get the first footer after the given position unless the given position is the last element.
+     *
      * @param position position after which to find the next footer
      * @return the first footer after the given position.
      */
@@ -327,6 +341,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
 
     /**
      * Get the {@link RecyclerView} for this adapter.
+     *
      * @return the {@link RecyclerView} for this adapter
      */
     public RecyclerView getRecyclerView() {
@@ -365,9 +380,9 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter  {@link BrickRecyclerAdapter} to notify
          * @param position Position of the item that has changed
-         * @param payload Optional parameter, use null to identify a "full" update
+         * @param payload  Optional parameter, use null to identify a "full" update
          */
         NotifyItemChangedWithPayloadRunnable(BrickRecyclerAdapter adapter, final int position, final Object payload) {
             this.adapter = adapter;
@@ -391,7 +406,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter  {@link BrickRecyclerAdapter} to notify
          * @param position Position of the item that has changed
          */
         NotifyItemChangedRunnable(BrickRecyclerAdapter adapter, final int position) {
@@ -415,7 +430,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter  {@link BrickRecyclerAdapter} to notify
          * @param position Position of the newly inserted item in the data set
          */
         NotifyItemInsertedRunnable(BrickRecyclerAdapter adapter, final int position) {
@@ -440,9 +455,9 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter      {@link BrickRecyclerAdapter} to notify
          * @param fromPosition Previous position of the item.
-         * @param toPosition New position of the item.
+         * @param toPosition   New position of the item.
          */
         NotifyItemMovedRunnable(BrickRecyclerAdapter adapter, final int fromPosition, final int toPosition) {
             this.adapter = adapter;
@@ -469,10 +484,10 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter       {@link BrickRecyclerAdapter} to notify
          * @param positionStart Position of the first item that has changed
-         * @param itemCount Number of items that have changed
-         * @param payload  Optional parameter, use null to identify a "full" update
+         * @param itemCount     Number of items that have changed
+         * @param payload       Optional parameter, use null to identify a "full" update
          */
         NotifyItemRangeChangedWithPayloadRunnable(BrickRecyclerAdapter adapter, final int positionStart, final int itemCount, final Object payload) {
             this.adapter = adapter;
@@ -498,9 +513,9 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter       {@link BrickRecyclerAdapter} to notify
          * @param positionStart Position of the first item that has changed
-         * @param itemCount Number of items that have changed
+         * @param itemCount     Number of items that have changed
          */
         NotifyItemRangeChangedRunnable(BrickRecyclerAdapter adapter, final int positionStart, final int itemCount) {
             this.adapter = adapter;
@@ -525,9 +540,9 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter       {@link BrickRecyclerAdapter} to notify
          * @param positionStart Position of the first item that has inserted
-         * @param itemCount Number of items that have inserted
+         * @param itemCount     Number of items that have inserted
          */
         NotifyItemRangeInsertedRunnable(BrickRecyclerAdapter adapter, final int positionStart, final int itemCount) {
             this.adapter = adapter;
@@ -552,9 +567,9 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter       {@link BrickRecyclerAdapter} to notify
          * @param positionStart Previous position of the first item that was removed
-         * @param itemCount Number of items removed from the data set
+         * @param itemCount     Number of items removed from the data set
          */
         NotifyItemRangeRemovedRunnable(BrickRecyclerAdapter adapter, final int positionStart, final int itemCount) {
             this.adapter = adapter;
@@ -578,7 +593,7 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
         /**
          * Constructor.
          *
-         * @param adapter {@link BrickRecyclerAdapter} to notify
+         * @param adapter  {@link BrickRecyclerAdapter} to notify
          * @param position Position of the item that has now been removed
          */
         NotifyItemRemovedRunnable(BrickRecyclerAdapter adapter, final int position) {

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
@@ -20,6 +20,7 @@ import com.wayfair.brickkit.size.SimpleBrickSize;
  */
 public abstract class BaseBrick {
     public static final int DEFAULT_MAX_SPAN_COUNT = 240;
+    public static final int INVALID_LAYOUT = -1;
 
     public static final BrickSize DEFAULT_SIZE_FULL_WIDTH = new SimpleBrickSize(DEFAULT_MAX_SPAN_COUNT) {
         @Override
@@ -75,7 +76,7 @@ public abstract class BaseBrick {
     /**
      * Constructor which uses the default padding.
      *
-     * @param padding  padding for this brick
+     * @param padding padding for this brick
      */
     public BaseBrick(BrickPadding padding) {
         this(DEFAULT_SIZE_FULL_WIDTH, padding);
@@ -94,9 +95,7 @@ public abstract class BaseBrick {
      *
      * @param holder BrickViewHolder which should be updated.
      */
-    public void onBindPlaceholder(BrickViewHolder holder) {
-        throw new UnsupportedOperationException(getClass().getSimpleName()
-                + " onBindPlaceholder(BrickViewHolder holder) method must be overridden within brick extending BaseBrick");
+    public void onBindSubsequentLayout(BrickViewHolder holder) {
     }
 
     /**
@@ -123,9 +122,8 @@ public abstract class BaseBrick {
      * @return The layout resource id for this brick's placeholder
      */
     @LayoutRes
-    public int getPlaceholderLayout() {
-        throw new UnsupportedOperationException(getClass().getSimpleName()
-                + " getPlaceholderLayout() method must be overridden within brick extending BaseBrick");
+    public int getSubsequentLayout() {
+        return INVALID_LAYOUT;
     }
 
     /**
@@ -366,13 +364,13 @@ public abstract class BaseBrick {
      * @param direction one of {@link ItemTouchHelper.UP}, {@link ItemTouchHelper.RIGHT},
      *                  {@link ItemTouchHelper.DOWN}, {@link ItemTouchHelper.LEFT},
      *                  {@link ItemTouchHelper.START}, {@link ItemTouchHelper.END}
-     *
      */
     public void dismissed(int direction) {
     }
 
     /**
      * Set the current DataManager this brick is connected to.
+     *
      * @param dataManager The current DataManager for this brick
      */
     public void setDataManager(BrickDataManager dataManager) {

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/LayoutBinder.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/LayoutBinder.java
@@ -5,11 +5,11 @@ import com.wayfair.brickkit.BrickViewHolder;
 /**
  * An object that will help bind the holder to the place holder view.
  */
-public interface PlaceholderBinder {
+public interface LayoutBinder {
     /**
      * Called when a placeholder from {@link ViewModelBrick} is going to be bound.
      *
      * @param holder the holder to bind with
      */
-    void onBindPlaceholder(BrickViewHolder holder);
+    void onBindLayout(BrickViewHolder holder);
 }

--- a/BrickKit/bricks/src/main/res/layout/text_brick_vm_placeholder.xml
+++ b/BrickKit/bricks/src/main/res/layout/text_brick_vm_placeholder.xml
@@ -1,20 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright © 2017 Wayfair. All rights reserved. -->
-<layout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright © 2017 Wayfair. All rights reserved. -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+        <variable
+            name="textViewModel"
+            type="com.wayfair.brickkit.models.TextViewModel" />
+    </data>
+
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" >
+        android:layout_height="wrap_content">
 
         <TextView
             android:id="@+id/text_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/black"
-            android:textSize="31sp"
             android:background="@android:color/darker_gray"
-            android:padding="@dimen/default_brick_content_padding" />
+            android:padding="@dimen/default_brick_content_padding"
+            android:text="@{textViewModel.text}"
+            android:textColor="@android:color/black"
+            android:textSize="31sp" />
 
     </RelativeLayout>
 


### PR DESCRIPTION
This PR will remove `onBindPlaceholder` in BaseBrick, and replace it with `onBindSubsequentLayout`.

This will help to normalize rebindings, and get people to think of placeholders as more of a "first" binding of the brick. With the previous implementation, it was almost as though we were implementing something that came "before" the first binding, so it was not widely used or understood. 

As of this PR, the ViewModelBrick will also get a set of methods for rebinding, called `replaceLayoutWith`. They take a combination of a binding id, a SparseArray of ViewModels, and a LayoutBinding action, which will get applied to the brick while the brick is getting bound. This will greatly facilitate adding in placeholders in practice - ANY layout can be used as a "placeholder", and no classes will have to be extended or modified to allow us that functionality. 

Demo video here: https://drive.google.com/file/d/1w8ZL3x89QyXG82BgX4Sk9hbpjdxPkB2-/view?usp=sharing
