### PR TITLE
Added method to refresh brick item and data

### DIFF
--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
@@ -1186,6 +1186,20 @@ public class BrickDataManagerTest {
     }
 
     @Test
+    public void testRefreshItem_noNotifyDataSetChanged() {
+        manager.refreshItem(brickTestHelper.generateBrick());
+
+        verify(headerBehavior, never()).onDataSetChanged();
+    }
+
+    @Test
+    public void testRefreshItemAndData_notifyDataSetChanged() {
+        manager.refreshItemAndData(brickTestHelper.generateBrick());
+
+        verify(headerBehavior).onDataSetChanged();
+    }
+
+    @Test
     public void testOnDestroy() {
         manager.onDestroyView();
 

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -795,6 +795,16 @@ public class BrickDataManager implements Serializable {
     }
 
     /**
+     * Refresh a brick and the data within the brick.
+     *
+     * @param item the brick to refresh
+     */
+    public void refreshItemAndData(BaseBrick item) {
+        refreshItem(item);
+        dataHasChanged();
+    }
+
+    /**
      * Update the visibility of the brick and set it invisible.
      *
      * @param item the brick to be hided


### PR DESCRIPTION
StickyHeader view data was not being refreshed during `refreshItems()`. May be related to issue https://github.com/wayfair/brickkit-android/issues/35 with the data not updating until scrolled (`dataHasChanged` is still false though in certain StickyHeader view cases), but this adds a method to explicitly update the data of a brick. 