### PR TITLE
Check to see if `items` is null before removing them

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -685,21 +685,23 @@ public class BrickDataManager implements Serializable {
      * @param items the bricks to remove
      */
     public void removeItems(Collection<? extends BaseBrick> items) {
-        this.items.removeAll(items);
-        for (BaseBrick item : items) {
-            removeFromIdCache(item);
-            removeFromTagCache(item);
-            item.setDataManager(null);
-        }
-        int visibleCount = getVisibleCount(items);
-        if (visibleCount > 0) {
-            dataHasChanged();
-            if (brickRecyclerAdapter != null) {
-                if (getRecyclerViewItems().size() > 0) {
-                    computePaddingPosition(getRecyclerViewItems().getFirst());
-                }
+        if (items != null) {
+            this.items.removeAll(items);
+            for (BaseBrick item : items) {
+                removeFromIdCache(item);
+                removeFromTagCache(item);
+                item.setDataManager(null);
+            }
+            int visibleCount = getVisibleCount(items);
+            if (visibleCount > 0) {
+                dataHasChanged();
+                if (brickRecyclerAdapter != null) {
+                    if (getRecyclerViewItems().size() > 0) {
+                        computePaddingPosition(getRecyclerViewItems().getFirst());
+                    }
 
-                brickRecyclerAdapter.safeNotifyDataSetChanged();
+                    brickRecyclerAdapter.safeNotifyDataSetChanged();
+                }
             }
         }
     }


### PR DESCRIPTION
This issue is causing `NullPointerException`s. Let's check that the `items` param is not null before we try to remove them from `this.items`.