### PR TITLE
Implement non-recyclable view model bricks

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickRecyclerAdapter.java
@@ -200,6 +200,12 @@ public class BrickRecyclerAdapter extends RecyclerView.Adapter<BrickViewHolder> 
     public void onBindViewHolder(BrickViewHolder holder, int position) {
         BaseBrick baseBrick = dataManager.brickAtPosition(position);
         if (baseBrick != null) {
+
+            // if the brick is not recyclable set the view holder to reflect that
+            if (!baseBrick.isRecyclable()) {
+                holder.setIsRecyclable(false);
+            }
+
             if (recyclerView.getLayoutManager() instanceof StaggeredGridLayoutManager) {
                 if (holder.itemView.getLayoutParams() instanceof StaggeredGridLayoutManager.LayoutParams) {
                     ((StaggeredGridLayoutManager.LayoutParams) holder.itemView.getLayoutParams()).setFullSpan(

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
@@ -443,7 +443,7 @@ public abstract class BaseBrick {
 
 
     /**
-     * Determine if the brick should get recycled
+     * Determine if the brick should get recycled.
      *
      * @return Whether the brick should get recycled
      */

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/BaseBrick.java
@@ -44,6 +44,7 @@ public abstract class BaseBrick {
     @StickyScrollMode
     private int stickyScrollMode = StickyScrollMode.SHOW_ON_SCROLL;
     private BrickDataManager dataManager;
+    private boolean isRecyclable = true;
 
     /**
      * Constructor.
@@ -62,6 +63,20 @@ public abstract class BaseBrick {
         this.spanSize = spanSize;
         this.spanSize.setBaseBrick(this);
         this.padding = padding;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param spanSize     size information for this brick
+     * @param padding      padding for this brick
+     * @param isRecyclable If the brick should get recycled (default is true)
+     */
+    public BaseBrick(BrickSize spanSize, BrickPadding padding, Boolean isRecyclable) {
+        this.spanSize = spanSize;
+        this.spanSize.setBaseBrick(this);
+        this.padding = padding;
+        this.isRecyclable = isRecyclable;
     }
 
     /**
@@ -424,5 +439,15 @@ public abstract class BaseBrick {
         sb.append("--");
 
         return sb.toString();
+    }
+
+
+    /**
+     * Determine if the brick should get recycled
+     *
+     * @return Whether the brick should get recycled
+     */
+    public Boolean isRecyclable() {
+        return this.isRecyclable;
     }
 }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
@@ -310,7 +310,7 @@ public final class ViewModelBrick extends BaseBrick implements ViewModel.ViewMod
 
 
         /**
-         * Sets if the brick will be recyclable
+         * Sets if the brick will be recyclable.
          *
          * @param recyclable the ability to recycle the brick
          * @return the builder

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/ViewModelBrick.java
@@ -31,7 +31,7 @@ public final class ViewModelBrick extends BaseBrick implements ViewModel.ViewMod
      * @param builder the builder
      */
     private ViewModelBrick(Builder builder) {
-        super(builder.spanSize, builder.padding);
+        super(builder.spanSize, builder.padding, builder.isRecyclable);
 
         this.layoutId = builder.layoutId;
         this.placeholderLayoutId = builder.placeholderLayoutId;
@@ -226,6 +226,7 @@ public final class ViewModelBrick extends BaseBrick implements ViewModel.ViewMod
         BrickSize spanSize = getDefaultSize();
         BrickPadding padding = getDefaultPadding();
         SwipeListener onDismiss = null;
+        boolean isRecyclable = true;
 
         /**
          * Builder constructor, requires only a {@link LayoutRes} to work.
@@ -304,6 +305,18 @@ public final class ViewModelBrick extends BaseBrick implements ViewModel.ViewMod
          */
         public Builder setOnDismiss(SwipeListener onDismiss) {
             this.onDismiss = onDismiss;
+            return this;
+        }
+
+
+        /**
+         * Sets if the brick will be recyclable
+         *
+         * @param recyclable the ability to recycle the brick
+         * @return the builder
+         */
+        public Builder setIsRecyclable(boolean recyclable) {
+            this.isRecyclable = recyclable;
             return this;
         }
 


### PR DESCRIPTION
This can be useful when adding a fragment to a brick which contains
state that should not be recycled.  One example is a map.  It is far
better to hold the map view rather than recycle and reload the map.