### PR TITLE
Added use bricks

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickFragment.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickFragment.java
@@ -109,6 +109,11 @@ public abstract class BrickFragment extends Fragment {
         return recyclerViewBackground;
     }
 
+    /**
+     * Set useBricks to false to not use bricks. This will not setup the recyclerview for the layout
+     * and you're able to inflate a fragment without using any Brickkit functionality
+     * @param useBricks
+     */
     public void setUseBricks(boolean useBricks) {
         this.useBricks = useBricks;
     }

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickFragment.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickFragment.java
@@ -23,30 +23,38 @@ import androidx.recyclerview.widget.RecyclerView;
  * Fragment which provides a simple interface for adding bricks / behaviors.
  */
 public abstract class BrickFragment extends Fragment {
+
     public BrickDataManager dataManager = new BrickDataManager(maxSpans());
     @ColorInt
     private int recyclerViewBackground = Color.TRANSPARENT;
+    private boolean useBricks = true;
 
     @Override
     @CallSuper
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View view;
-        if (orientation() == OrientationHelper.VERTICAL) {
-            view = inflater.inflate(R.layout.vertical_fragment_brick, container, false);
-        } else {
-            view = inflater.inflate(R.layout.horizontal_fragment_brick, container, false);
-        }
+        if (useBricks) {
+            View view;
+            if (orientation() == OrientationHelper.VERTICAL) {
+                view = inflater.inflate(R.layout.vertical_fragment_brick, container, false);
+            } else {
+                view = inflater.inflate(R.layout.horizontal_fragment_brick, container, false);
+            }
 
-        RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.recycler_view);
-        recyclerView.setBackgroundColor(recyclerViewBackground);
-        ((DefaultItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
-        dataManager.setRecyclerView(getContext(), recyclerView, orientation(), reverse(), view);
-        return view;
+            RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.recycler_view);
+            recyclerView.setBackgroundColor(recyclerViewBackground);
+            ((DefaultItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
+            dataManager.setRecyclerView(getContext(), recyclerView, orientation(), reverse(), view);
+            return view;
+        } else {
+            return null;
+        }
     }
 
     @Override
     public void onDestroyView() {
-        dataManager.onDestroyView();
+        if (useBricks) {
+            dataManager.onDestroyView();
+        }
         super.onDestroyView();
     }
 
@@ -99,5 +107,9 @@ public abstract class BrickFragment extends Fragment {
     @ColorInt
     public int getRecyclerViewBackground() {
         return recyclerViewBackground;
+    }
+
+    public void setUseBricks(boolean useBricks) {
+        this.useBricks = useBricks;
     }
 }


### PR DESCRIPTION
By default bricks will be used. If we specify `setUseBricks(false)` in the newInstance() for a fragment, then BrickFragment won't inflate the recycler view. I'm using this as an experimentation on UGC. We don't have to merge this in, but making a PR to get feedback and visibility.
Using a local Brickkit build to test this.