### PR TITLE
clear brickkit collections in onDestroyView to avoid memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .gradle/
+.idea/

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -1123,6 +1123,9 @@ public class BrickDataManager implements Serializable {
             behavior.detachFromRecyclerView(getRecyclerView());
         }
         behaviors.clear();
+        items.clear();
+        idCache.clear();
+        tagCache.clear();
         if (recyclerView != null) {
             recyclerView.setAdapter(null);
         }


### PR DESCRIPTION
clear brickkit collections in onDestroyView to avoid memory leak
fix .gitignore to exclude IntelliJ project files