### PR TITLE
Restoration of Brick Updates

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -1301,9 +1301,6 @@ public class BrickDataManager implements Serializable, BrickProvider {
             behavior.detachFromRecyclerView(getRecyclerView());
         }
         behaviors.clear();
-        items.clear();
-        idCache.clear();
-        tagCache.clear();
         if (recyclerView != null) {
             recyclerView.setAdapter(null);
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 **Merged pull requests:**
 - Code hardening with index out of bounds exceptions in BrickKitDataManager.
 
-## [0.9.45](https://github.com/wayfair/brickkit-android/tree/0.9.45) (2020-02-02)
+## [0.9.46](https://github.com/wayfair/brickkit-android/tree/0.9.46) (2020-01-21)
+[Full Changelog](https://github.com/wayfair/brickkit-android/compare/0.9.45...0.9.46)
+
+**Merged pull requests:**
+- Code hardening with index out of bounds exceptions in BrickKitDataManager.
+
+## [0.9.45](https://github.com/wayfair/brickkit-android/tree/0.9.45) (2020-01-16)
 [Full Changelog](https://github.com/wayfair/brickkit-android/compare/0.9.44...0.9.45)
 
 **Merged pull requests:**
-## [0.9.44](https://github.com/wayfair/brickkit-android/tree/0.9.44) (2020-02-02)
+## [0.9.44](https://github.com/wayfair/brickkit-android/tree/0.9.44) (2020-01-02)
 [Full Changelog](https://github.com/wayfair/brickkit-android/compare/0.9.43...0.9.44)
 
 **Merged pull requests:**


### PR DESCRIPTION
**Changes:**

I removed the memory leak fix, from version _0.9.43_, to restore brick updates.