### PR TITLE
Remove unused method BrickDataManager.computePaddingPositionSafelyForFirstItem()

### DIFF
--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/BrickDataManagerTest.java
@@ -1240,43 +1240,6 @@ public class BrickDataManagerTest {
     }
 
     @Test
-    public void testComputePaddingPositionSafelyForFirstItem_withZeroItems_resultsIn_NO_PADDING_POSITION_Value() {
-        // Given
-        BrickDataManager dataManager = new BrickDataManager();
-
-        // When
-        int paddingPosition = dataManager.computePaddingPositionSafelyForFirstItem();
-
-        // Verify
-        assertEquals(BrickDataManager.NO_PADDING_POSITION, paddingPosition);
-    }
-
-    @Test
-    public void testComputePaddingPositionSafelyForFirstItem_withMultipleItems_resultsInAccuratePosition() {
-        // Given
-        BrickDataManager dataManager = new BrickDataManager();
-        dataManager.setHorizontalRecyclerView(new RecyclerView(ApplicationProvider.getApplicationContext()));
-
-        // When
-        List<BaseBrick> newItems = new LinkedList<>();
-
-        BaseBrick brick1 = generateBrick();
-        brick1.setHidden(false);
-        newItems.add(brick1);
-
-        BaseBrick brick2 = generateBrick();
-        brick2.setHidden(false);
-        newItems.add(brick1);
-
-        dataManager.addLast(newItems);
-        dataManager.dataHasChanged();
-        int paddingPosition = dataManager.computePaddingPositionSafelyForFirstItem();
-
-        // Verify
-        assertNotEquals(BrickDataManager.NO_PADDING_POSITION, paddingPosition);
-    }
-
-    @Test
     public void testSafeNotifyItemInserted() {
         // Given
         List<BaseBrick> items = new LinkedList<>();

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.NoSuchElementException;
 
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
@@ -873,19 +872,6 @@ public class BrickDataManager implements Serializable, BrickProvider {
         if (index != NO_INDEX) {
             recyclerView.smoothScrollToPosition(index);
         }
-    }
-
-    /**
-     * Safely checks / Determines if the brick is on the left wall, first row, right wall, last row.
-     * If a {@link NoSuchElementException} is thrown when retrieving the first brick, it is caught.
-     *
-     * @return index of first modified, non-null item or {@link #NO_PADDING_POSITION} for a null
-     * brick.
-     */
-    @VisibleForTesting
-    @SuppressWarnings("UnusedReturnValue")
-    int computePaddingPositionSafelyForFirstItem() {
-        return computePaddingPosition(getRecyclerViewItems().peek());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/wayfair/brickkit-android/issues/198