### PR TITLE
Convert DataModel.isReady to a val

### DIFF
--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/DataModelTest.kt
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/DataModelTest.kt
@@ -12,7 +12,7 @@ class DataModelTest {
 
     @Test
     fun testIsReady() {
-        assertTrue(dataModel.isReady())
+        assertTrue(dataModel.isReady)
     }
 
     @Test

--- a/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/ViewModelBrickTest.kt
+++ b/BrickKit/bricks/src/androidTest/java/com/wayfair/brickkit/brick/ViewModelBrickTest.kt
@@ -224,13 +224,13 @@ class ViewModelBrickTest {
         val dataModel = TextDataModel(TEXT)
         val viewModel = TextViewModel(dataModel)
 
-        val countDownLatch = CountDownLatch(1)
-        viewModel.addUpdateListener { countDownLatch.countDown() }
-
         val viewModelBrick = ViewModelBrick.Builder(R.layout.text_brick_vm)
             .addViewModel(BR.viewModel, viewModel)
             .setPlaceholder(R.layout.text_brick_vm_placeholder)
             .build()
+
+        val countDownLatch = CountDownLatch(1)
+        viewModel.addUpdateListener { countDownLatch.countDown() }
 
         assertFalse(viewModelBrick.isHidden)
 
@@ -260,7 +260,8 @@ class ViewModelBrickTest {
                 notifyChange()
             }
 
-        override fun isReady(): Boolean = text.isNotEmpty()
+        override val isReady: Boolean
+            get() = text.isNotEmpty()
     }
 
     companion object {

--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/DataModel.kt
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/brick/DataModel.kt
@@ -18,7 +18,7 @@ abstract class DataModel : Serializable {
      *
      * @param updateListener the listener to add
      */
-    fun addUpdateListener(updateListener: DataModelUpdateListener) {
+    open fun addUpdateListener(updateListener: DataModelUpdateListener) {
         updateListeners.add(updateListener)
     }
 
@@ -27,14 +27,14 @@ abstract class DataModel : Serializable {
      *
      * @param updateListener the listener to remove
      */
-    fun removeUpdateListener(updateListener: DataModelUpdateListener) {
+    open fun removeUpdateListener(updateListener: DataModelUpdateListener) {
         updateListeners.remove(updateListener)
     }
 
     /**
      * This function is called when you are ready to notify listeners that the data has changed.
      */
-    fun notifyChange() {
+    open fun notifyChange() {
         val handler = Handler(Looper.getMainLooper())
 
         updateListeners.forEach { updateListener ->
@@ -47,7 +47,7 @@ abstract class DataModel : Serializable {
      *
      * @return true if the data is ready, defaults to true
      */
-    open fun isReady(): Boolean = true
+    open val isReady: Boolean = true
 
     /**
      * The interface required to be implemented in order to listen for changes on [DataModel]s.


### PR DESCRIPTION
This change also fixes a flaky test and makes other datamodel methods open so that they can
be mocked.

Fixes https://github.com/wayfair/brickkit-android/issues/228