### PR TITLE
Fix crash on brickDataManager destroy

### DIFF
--- a/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.kt
+++ b/BrickKit/bricks/src/main/java/com/wayfair/brickkit/BrickDataManager.kt
@@ -10,6 +10,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.wayfair.brickkit.animator.AvoidFlickerItemAnimator
 import com.wayfair.brickkit.brick.BaseBrick
 import java.io.Serializable
+import java.lang.IllegalStateException
+import android.util.Log
 
 /**
  * Class which maintains a collection of bricks and manages how they are laid out in an provided RecyclerView.
@@ -396,7 +398,11 @@ open class BrickDataManager : Serializable {
      * Method called to release any related resources.
      */
     open fun onDestroyView() {
-        recyclerView?.adapter = null
+        try {
+            recyclerView?.adapter = null
+        } catch (e: IllegalStateException) {
+            Log.w(TAG, "Catching RecyclerView not registered exception")
+        }
         brickRecyclerAdapter = null
         recyclerView = null
     }
@@ -626,6 +632,7 @@ open class BrickDataManager : Serializable {
     }
 
     companion object {
+        private val TAG = BrickDataManager::class.java.name
         const val SPAN_COUNT = 240
     }
 }


### PR DESCRIPTION
Catches an IllegalStateException. Firebase crash here: https://console.firebase.google.com/u/0/project/prod-birch-lane/crashlytics/app/android:com.wayfair.birchlane/issues/3916ea127d42346d14392fe81ea14adf?versions=5.158-beta-20220706%20(2144810)&time=last-twenty-four-hours&types=crash&sessionEventKey=62C6B7D9024A000120301E5DC5AC43A3_1696024205626508838

Related Issue here: https://github.com/wayfair/brickkit-android/issues/259