### PR TITLE
Update Publish Script to enable gradlew commands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           git fetch --unshallow
           sudo bash -c "echo '$GPG_KEY_CONTENTS' | base64 -d > '$SIGNING_SECRET_KEY_RING_FILE'"
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
       - name: Release build
         # assembleRelease for all modules, excluding non-library modules: sample, ui-components sample, docs
         run: ./gradlew assembleRelease -x :brickkit-android:assembleRelease -x


### PR DESCRIPTION
This should fix the issue with .gradlew commands not being found in the publish script. Solution found here on this issue: https://github.com/orgs/community/discussions/25526